### PR TITLE
[KD-41] 로딩 분기 흐름 및 페이지 mock 데이터 구조 정리

### DIFF
--- a/src/pages/Loading/LoadingPage.tsx
+++ b/src/pages/Loading/LoadingPage.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from 'react';
+
 import {
   aiAnalysisDoneIcon,
   aiAnalysisReadyIcon,
@@ -17,104 +19,94 @@ import {
 import { qrBlackIcon } from '@/shared/icon/resultIcons';
 import AppHeader from '@/shared/ui/app-header';
 
+import { useLoadingPage } from './hooks/useLoadingPage';
 import { useLoadingProgress } from './hooks/useLoadingProgress';
 import * as styles from './styles/loadingPage.css';
 
-type LoadingStepMessage = {
-  activeDescription: string;
-  doneDescription: string;
-  pendingDescription: string;
-  title: string;
+import type { LoadingState, LoadingStepId } from './types/loadingPage.types';
+
+type StepIconSet = {
+  active: string;
+  done: string;
+  pending: string;
 };
 
-const mainSteps: LoadingStepMessage[] = [
-  {
-    activeDescription: '주소를 읽어오고 있습니다...',
-    doneDescription: '주소 읽기가 완료되었습니다.',
-    pendingDescription: '주소 디코딩을 준비 중입니다...',
-    title: 'QR 코드 디코딩',
-  },
-  {
-    activeDescription: '딥러닝 엔진이 위험 요소를 탐지 중입니다...',
-    doneDescription: '위험 요소 탐지가 완료되었습니다.',
-    pendingDescription: '위험 분석을 준비 중입니다...',
-    title: 'AI 위험 분석',
-  },
-  {
-    activeDescription: '위험 지표를 종합하는 중입니다...',
-    doneDescription: '종합 위험도 산출이 완료되었습니다.',
-    pendingDescription: '위험도 산출을 준비 중입니다...',
-    title: '종합 위험도 산출',
-  },
-  {
-    activeDescription: '상세 보안 리포트를 구성 중입니다...',
-    doneDescription: '보안 리포트 작성이 완료되었습니다.',
-    pendingDescription: '리포트 작성을 준비 중입니다...',
-    title: '리포트 작성',
-  },
-  {
-    activeDescription: '곧 결과 페이지로 이동합니다...',
-    doneDescription: '결과 페이지로 이동합니다.',
-    pendingDescription: '최종 결과 정리를 준비 중입니다...',
-    title: '분석 완료',
-  },
-];
-
-const analysisDetailSteps = [
-  {
-    title: '리다이렉트 경로 분석',
-  },
-  {
-    title: '글로벌 보안 DB 대조',
-  },
-  {
-    title: '도메인 사칭 분석',
-  },
-  {
-    title: '서버 및 인증서 검사',
-  },
-] as const;
-
+const availableLoadingCases = [1, 2, 3, 4, 5, 6, 7, 8] as const;
 const progressRadius = 100;
 const progressCircumference = 2 * Math.PI * progressRadius;
 
-const stateLabel = {
+const stateLabel: Record<LoadingState, string> = {
   active: '진행 중',
   done: '완료',
   pending: '준비',
-} as const;
+};
 
-const stepIcons = [
-  {
-    done: decodingDoneIcon,
-    pending: decodingReadyIcon,
-    ready: decodingReadyIcon,
-  },
-  {
+const stepIconMap: Record<LoadingStepId, StepIconSet> = {
+  aiAnalysis: {
+    active: aiAnalysisReadyIcon,
     done: aiAnalysisDoneIcon,
     pending: aiAnalysisReadyIcon,
-    ready: aiAnalysisReadyIcon,
   },
-  {
-    done: riskScoreDoneIcon,
-    pending: riskScoreReadyIcon,
-    ready: riskScoreReadyIcon,
-  },
-  {
-    done: reportDoneIcon,
-    pending: reportReadyIcon,
-    ready: reportReadyIcon,
-  },
-  {
+  completed: {
+    active: analysisReadyIcon,
     done: analysisDoneIcon,
     pending: analysisPendingIcon,
-    ready: analysisReadyIcon,
   },
-] as const;
+  decode: {
+    active: decodingReadyIcon,
+    done: decodingDoneIcon,
+    pending: decodingReadyIcon,
+  },
+  externalApi: {
+    active: analysisReadyIcon,
+    done: analysisDoneIcon,
+    pending: analysisPendingIcon,
+  },
+  internalDb: {
+    active: analysisReadyIcon,
+    done: analysisDoneIcon,
+    pending: analysisPendingIcon,
+  },
+  redirect: {
+    active: analysisReadyIcon,
+    done: analysisDoneIcon,
+    pending: analysisPendingIcon,
+  },
+  report: {
+    active: reportReadyIcon,
+    done: reportDoneIcon,
+    pending: reportReadyIcon,
+  },
+  riskScore: {
+    active: riskScoreReadyIcon,
+    done: riskScoreDoneIcon,
+    pending: riskScoreReadyIcon,
+  },
+  shortUrlCheck: {
+    active: analysisReadyIcon,
+    done: analysisDoneIcon,
+    pending: analysisPendingIcon,
+  },
+};
 
 export default function LoadingPage() {
-  const { getAnalysisDetailState, getMainStepState, progress, statusDescription } =
-    useLoadingProgress();
+  const {
+    handleCaseChange,
+    handleRandomCaseChange,
+    handleSequentialDemoStart,
+    isSequentialDemoMode,
+    loadingCaseNumber,
+    loadingPageData,
+  } = useLoadingPage();
+  const { getDetailStepState, getStepState, progress, statusDescription, visibleStepCount } =
+    useLoadingProgress(loadingPageData.steps, {
+      progressIntervalMs: loadingPageData.progressIntervalMs,
+      revealStepsSequentially: isSequentialDemoMode,
+    });
+  const visibleSteps = useMemo(
+    () => loadingPageData.steps.slice(0, visibleStepCount),
+    [loadingPageData.steps, visibleStepCount],
+  );
 
   const dashOffset = progressCircumference - (progress / 100) * progressCircumference;
 
@@ -154,22 +146,17 @@ export default function LoadingPage() {
 
         <section className={styles.flowSection}>
           <ol className={styles.flowList}>
-            {mainSteps.map((step, index) => {
-              const state = getMainStepState(index);
-              const iconSet = stepIcons[index];
-              const iconSrc =
-                state === 'done'
-                  ? iconSet.done
-                  : state === 'active'
-                    ? iconSet.ready
-                    : iconSet.pending;
+            {visibleSteps.map((step, index) => {
+              const state = getStepState(index);
+              const iconSet = stepIconMap[step.id];
+              const iconSrc = iconSet[state];
               const flowItemClassName =
-                index < mainSteps.length - 1
+                index < visibleSteps.length - 1
                   ? `${styles.flowItem} ${styles.flowItemWithLine}`
                   : styles.flowItem;
 
               return (
-                <li className={flowItemClassName} key={step.title}>
+                <li className={flowItemClassName} key={step.id}>
                   <span className={`${styles.flowIcon} ${styles.flowIconState[state]}`}>
                     <img alt="" className={styles.flowIconImage} src={iconSrc} />
                   </span>
@@ -189,10 +176,10 @@ export default function LoadingPage() {
                       {stateLabel[state]}
                     </p>
 
-                    {index === 1 ? (
+                    {step.details && step.details.length > 0 ? (
                       <ul className={styles.detailList}>
-                        {analysisDetailSteps.map((detailStep, detailIndex) => {
-                          const detailState = getAnalysisDetailState(detailIndex);
+                        {step.details.map((detailStep, detailIndex) => {
+                          const detailState = getDetailStepState(index, detailIndex);
                           const detailIconSrc =
                             detailState === 'done'
                               ? completedShieldIcon
@@ -230,6 +217,53 @@ export default function LoadingPage() {
               );
             })}
           </ol>
+        </section>
+
+        <section className={styles.caseControlSection}>
+          <div className={styles.caseControlHeader}>
+            <p className={styles.caseControlTitle}>테스트 케이스 선택</p>
+            <p className={styles.caseControlCurrent}>
+              현재 case {loadingCaseNumber}
+              {isSequentialDemoMode ? ' · 순차 분기 데모' : ' · 전체 흐름 보기'}
+            </p>
+          </div>
+
+          <div className={styles.caseButtonList}>
+            {availableLoadingCases.map((caseNumber) => (
+              <button
+                className={
+                  caseNumber === loadingCaseNumber
+                    ? `${styles.caseButton} ${styles.caseButtonActive}`
+                    : styles.caseButton
+                }
+                key={caseNumber}
+                onClick={() => handleCaseChange(caseNumber)}
+                type="button"
+              >
+                case {caseNumber}
+              </button>
+            ))}
+
+            <button
+              className={`${styles.caseButton} ${styles.randomCaseButton}`}
+              onClick={handleRandomCaseChange}
+              type="button"
+            >
+              랜덤
+            </button>
+
+            <button
+              className={
+                isSequentialDemoMode
+                  ? `${styles.caseButton} ${styles.branchDemoButton} ${styles.branchDemoButtonActive}`
+                  : `${styles.caseButton} ${styles.branchDemoButton}`
+              }
+              onClick={handleSequentialDemoStart}
+              type="button"
+            >
+              순차 분기 데모
+            </button>
+          </div>
         </section>
       </section>
     </main>

--- a/src/pages/Loading/api/fetchLoadingPageData.ts
+++ b/src/pages/Loading/api/fetchLoadingPageData.ts
@@ -1,0 +1,64 @@
+import { getLoadingSteps } from '../loadingScenario';
+
+import type {
+  LoadingCaseNumber,
+  LoadingPageData,
+  LoadingRevealMode,
+} from '../types/loadingPage.types';
+
+const MOCK_LOADING_DELAY_MS = 120;
+const DEFAULT_PROGRESS_INTERVAL_MS = 90;
+
+function buildLoadingPageData(
+  caseNumber: LoadingCaseNumber,
+  revealMode: LoadingRevealMode,
+): LoadingPageData {
+  return {
+    caseNumber,
+    progressIntervalMs: DEFAULT_PROGRESS_INTERVAL_MS,
+    revealMode,
+    steps: getLoadingSteps(caseNumber),
+  };
+}
+
+export const mockLoadingPageDataByCase: Record<LoadingCaseNumber, LoadingPageData> = {
+  1: buildLoadingPageData(1, 'full'),
+  2: buildLoadingPageData(2, 'full'),
+  3: buildLoadingPageData(3, 'full'),
+  4: buildLoadingPageData(4, 'full'),
+  5: buildLoadingPageData(5, 'full'),
+  6: buildLoadingPageData(6, 'full'),
+  7: buildLoadingPageData(7, 'full'),
+  8: buildLoadingPageData(8, 'full'),
+};
+
+export const mockSequentialLoadingPageDataByCase: Record<LoadingCaseNumber, LoadingPageData> = {
+  1: buildLoadingPageData(1, 'sequential'),
+  2: buildLoadingPageData(2, 'sequential'),
+  3: buildLoadingPageData(3, 'sequential'),
+  4: buildLoadingPageData(4, 'sequential'),
+  5: buildLoadingPageData(5, 'sequential'),
+  6: buildLoadingPageData(6, 'sequential'),
+  7: buildLoadingPageData(7, 'sequential'),
+  8: buildLoadingPageData(8, 'sequential'),
+};
+
+export async function fetchLoadingPageData(
+  caseNumber: LoadingCaseNumber,
+  revealMode: LoadingRevealMode,
+): Promise<LoadingPageData> {
+  await new Promise((resolve) => {
+    window.setTimeout(resolve, MOCK_LOADING_DELAY_MS);
+  });
+
+  return getInitialLoadingPageData(caseNumber, revealMode);
+}
+
+export function getInitialLoadingPageData(
+  caseNumber: LoadingCaseNumber,
+  revealMode: LoadingRevealMode,
+): LoadingPageData {
+  return revealMode === 'sequential'
+    ? mockSequentialLoadingPageDataByCase[caseNumber]
+    : mockLoadingPageDataByCase[caseNumber];
+}

--- a/src/pages/Loading/hooks/useLoadingPage.ts
+++ b/src/pages/Loading/hooks/useLoadingPage.ts
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { fetchLoadingPageData, getInitialLoadingPageData } from '../api/fetchLoadingPageData';
+import { isLoadingCaseNumber } from '../loadingScenario';
+
+import type {
+  LoadingCaseNumber,
+  LoadingPageData,
+  LoadingRevealMode,
+} from '../types/loadingPage.types';
+
+type UseLoadingPageReturn = {
+  handleCaseChange: (caseNumber: LoadingCaseNumber) => void;
+  handleRandomCaseChange: () => void;
+  handleSequentialDemoStart: () => void;
+  isSequentialDemoMode: boolean;
+  loadingCaseNumber: LoadingCaseNumber;
+  loadingPageData: LoadingPageData;
+};
+
+const DEFAULT_LOADING_CASE: LoadingCaseNumber = 6;
+const AVAILABLE_LOADING_CASES: LoadingCaseNumber[] = [1, 2, 3, 4, 5, 6, 7, 8];
+
+function resolveInitialLoadingCaseNumber() {
+  if (typeof window === 'undefined') {
+    return DEFAULT_LOADING_CASE;
+  }
+
+  const caseParam = Number(new URLSearchParams(window.location.search).get('case'));
+
+  if (isLoadingCaseNumber(caseParam)) {
+    return caseParam;
+  }
+
+  return DEFAULT_LOADING_CASE;
+}
+
+function updateCaseSearchParam(caseNumber: LoadingCaseNumber) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const searchParams = new URLSearchParams(window.location.search);
+  searchParams.set('case', String(caseNumber));
+
+  const nextSearch = searchParams.toString();
+  const nextUrl = nextSearch
+    ? `${window.location.pathname}?${nextSearch}`
+    : window.location.pathname;
+
+  window.history.replaceState(null, '', nextUrl);
+}
+
+export function useLoadingPage(): UseLoadingPageReturn {
+  const [loadingCaseNumber, setLoadingCaseNumber] = useState<LoadingCaseNumber>(
+    resolveInitialLoadingCaseNumber,
+  );
+  const [revealMode, setRevealMode] = useState<LoadingRevealMode>('full');
+  const [scenarioVersion, setScenarioVersion] = useState(0);
+  const [loadingPageData, setLoadingPageData] = useState<LoadingPageData>(() =>
+    getInitialLoadingPageData(resolveInitialLoadingCaseNumber(), 'full'),
+  );
+
+  useEffect(() => {
+    setLoadingPageData(getInitialLoadingPageData(loadingCaseNumber, revealMode));
+
+    let isMounted = true;
+
+    const loadLoadingPageData = async () => {
+      const response = await fetchLoadingPageData(loadingCaseNumber, revealMode);
+
+      if (isMounted) {
+        setLoadingPageData(response);
+      }
+    };
+
+    void loadLoadingPageData();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [loadingCaseNumber, revealMode, scenarioVersion]);
+
+  const handleCaseChange = useCallback((caseNumber: LoadingCaseNumber) => {
+    setLoadingCaseNumber(caseNumber);
+    setRevealMode('full');
+    setScenarioVersion((prev) => prev + 1);
+    updateCaseSearchParam(caseNumber);
+  }, []);
+
+  const handleRandomCaseChange = useCallback(() => {
+    const randomIndex = Math.floor(Math.random() * AVAILABLE_LOADING_CASES.length);
+    const randomCase = AVAILABLE_LOADING_CASES[randomIndex];
+
+    handleCaseChange(randomCase);
+  }, [handleCaseChange]);
+
+  const handleSequentialDemoStart = useCallback(() => {
+    setRevealMode('sequential');
+    setScenarioVersion((prev) => prev + 1);
+  }, []);
+
+  const isSequentialDemoMode = revealMode === 'sequential';
+
+  return {
+    handleCaseChange,
+    handleRandomCaseChange,
+    handleSequentialDemoStart,
+    isSequentialDemoMode,
+    loadingCaseNumber,
+    loadingPageData,
+  };
+}

--- a/src/pages/Loading/hooks/useLoadingPage.ts
+++ b/src/pages/Loading/hooks/useLoadingPage.ts
@@ -62,15 +62,25 @@ export function useLoadingPage(): UseLoadingPageReturn {
   );
 
   useEffect(() => {
-    setLoadingPageData(getInitialLoadingPageData(loadingCaseNumber, revealMode));
+    const fallbackData = getInitialLoadingPageData(loadingCaseNumber, revealMode);
+
+    setLoadingPageData(fallbackData);
 
     let isMounted = true;
 
     const loadLoadingPageData = async () => {
-      const response = await fetchLoadingPageData(loadingCaseNumber, revealMode);
+      try {
+        const response = await fetchLoadingPageData(loadingCaseNumber, revealMode);
 
-      if (isMounted) {
-        setLoadingPageData(response);
+        if (isMounted) {
+          setLoadingPageData(response);
+        }
+      } catch (error) {
+        console.error('Failed to load loading page data.', error);
+
+        if (isMounted) {
+          setLoadingPageData(fallbackData);
+        }
       }
     };
 

--- a/src/pages/Loading/hooks/useLoadingProgress.ts
+++ b/src/pages/Loading/hooks/useLoadingProgress.ts
@@ -1,22 +1,41 @@
 import { useEffect, useMemo, useState } from 'react';
 
-const MAX_PROGRESS = 100;
-const PROGRESS_INTERVAL_MS = 90;
+import {
+  getProgressRanges,
+  getProgressState,
+  getThresholds,
+  resolveLocalProgress,
+} from '../loadingProgressUtils';
 
-export type LoadingState = 'active' | 'done' | 'pending';
+import type { LoadingDetailStep, LoadingState, LoadingStep } from '../types/loadingPage.types';
+
+const MAX_PROGRESS = 100;
+const DEFAULT_PROGRESS_INTERVAL_MS = 90;
 
 type LoadingProgressResult = {
-  getAnalysisDetailState: (index: number) => LoadingState;
-  getMainStepState: (index: number) => LoadingState;
+  visibleStepCount: number;
+  getDetailStepState: (stepIndex: number, detailIndex: number) => LoadingState;
+  getStepState: (index: number) => LoadingState;
   progress: number;
   statusDescription: string;
 };
 
-const mainStepThresholds = [18, 78, 88, 96, 100];
-const analysisDetailThresholds = [34, 48, 62, 76];
+type UseLoadingProgressOptions = {
+  progressIntervalMs?: number;
+  revealStepsSequentially?: boolean;
+};
 
-export function useLoadingProgress(): LoadingProgressResult {
+export function useLoadingProgress(
+  steps: LoadingStep[],
+  options?: UseLoadingProgressOptions,
+): LoadingProgressResult {
   const [progress, setProgress] = useState(0);
+  const progressIntervalMs = options?.progressIntervalMs ?? DEFAULT_PROGRESS_INTERVAL_MS;
+  const revealStepsSequentially = options?.revealStepsSequentially ?? true;
+
+  useEffect(() => {
+    setProgress(0);
+  }, [steps]);
 
   useEffect(() => {
     const intervalId = window.setInterval(() => {
@@ -27,73 +46,77 @@ export function useLoadingProgress(): LoadingProgressResult {
 
         return prev + 1;
       });
-    }, PROGRESS_INTERVAL_MS);
+    }, progressIntervalMs);
 
     return () => {
       window.clearInterval(intervalId);
     };
-  }, []);
+  }, [progressIntervalMs, steps]);
 
-  const activeMainStepIndex = useMemo(() => {
-    const foundIndex = mainStepThresholds.findIndex((threshold) => progress < threshold);
+  const stepThresholds = useMemo(() => getThresholds(steps), [steps]);
+  const stepRanges = useMemo(() => getProgressRanges(stepThresholds), [stepThresholds]);
+  const activeStepIndex = useMemo(() => {
+    const foundIndex = stepThresholds.findIndex((threshold) => progress < threshold);
     return foundIndex === -1 ? null : foundIndex;
-  }, [progress]);
-
-  const getMainStepState = (index: number): LoadingState => {
-    if (activeMainStepIndex === null) {
-      return 'done';
+  }, [progress, stepThresholds]);
+  const visibleStepCount = useMemo(() => {
+    if (!revealStepsSequentially) {
+      return steps.length;
     }
 
-    if (index < activeMainStepIndex) {
-      return 'done';
+    if (activeStepIndex === null) {
+      return steps.length;
     }
 
-    if (index === activeMainStepIndex) {
-      return 'active';
-    }
+    return Math.min(activeStepIndex + 1, steps.length);
+  }, [activeStepIndex, revealStepsSequentially, steps.length]);
 
-    return 'pending';
+  const getStepState = (index: number): LoadingState => {
+    return getProgressState(progress, stepThresholds, index);
   };
 
-  const getAnalysisDetailState = (index: number): LoadingState => {
-    const analysisStepState = getMainStepState(1);
+  const getDetailStepState = (stepIndex: number, detailIndex: number): LoadingState => {
+    const step = steps[stepIndex];
+    const detailSteps = step?.details;
 
-    if (analysisStepState === 'pending') {
+    if (!detailSteps || detailSteps.length === 0) {
       return 'pending';
     }
 
-    if (analysisStepState === 'done') {
+    const stepState = getStepState(stepIndex);
+
+    if (stepState === 'pending') {
+      return 'pending';
+    }
+
+    if (stepState === 'done') {
       return 'done';
     }
 
-    const activeSubStepIndex = analysisDetailThresholds.findIndex(
-      (threshold) => progress < threshold,
-    );
-    const resolvedActiveSubStepIndex = activeSubStepIndex === -1 ? null : activeSubStepIndex;
+    const stepRange = stepRanges[stepIndex];
 
-    if (resolvedActiveSubStepIndex === null) {
-      return 'done';
+    if (!stepRange) {
+      return 'pending';
     }
 
-    if (index < resolvedActiveSubStepIndex) {
-      return 'done';
-    }
+    const localProgress = resolveLocalProgress(progress, stepRange);
+    const detailThresholds = getThresholds<LoadingDetailStep>(detailSteps);
 
-    if (index === resolvedActiveSubStepIndex) {
-      return 'active';
-    }
-
-    return 'pending';
+    return getProgressState(localProgress, detailThresholds, detailIndex);
   };
 
-  const statusDescription =
-    progress < 100
-      ? '시스템을 안전하게 점검하고 있습니다.'
-      : '분석이 완료되었습니다. 결과 페이지로 이동합니다.';
+  const statusDescription = useMemo(() => {
+    if (activeStepIndex === null) {
+      return steps[steps.length - 1]?.doneDescription ?? '분석이 완료되었습니다.';
+    }
+
+    return steps[activeStepIndex]?.activeDescription ?? '분석을 진행하고 있습니다.';
+  }, [activeStepIndex, steps]);
 
   return {
-    getAnalysisDetailState,
-    getMainStepState,
+    visibleStepCount,
+    getDetailStepState,
+    getStepState,
     progress,
     statusDescription,
   };

--- a/src/pages/Loading/loadingProgressUtils.ts
+++ b/src/pages/Loading/loadingProgressUtils.ts
@@ -1,0 +1,71 @@
+import type { LoadingState } from './types/loadingPage.types';
+
+type WeightedStep = {
+  weight: number;
+};
+
+type ProgressRange = {
+  end: number;
+  start: number;
+};
+
+const MAX_PROGRESS = 100;
+
+export function getThresholds<T extends WeightedStep>(items: T[]) {
+  const totalWeight = items.reduce((sum, item) => sum + item.weight, 0);
+  let accumulatedWeight = 0;
+
+  return items.map((item, index) => {
+    accumulatedWeight += item.weight;
+
+    if (index === items.length - 1) {
+      return MAX_PROGRESS;
+    }
+
+    return Math.round((accumulatedWeight / totalWeight) * MAX_PROGRESS);
+  });
+}
+
+export function getProgressRanges(thresholds: number[]): ProgressRange[] {
+  let previousThreshold = 0;
+
+  return thresholds.map((threshold) => {
+    const range = {
+      end: threshold,
+      start: previousThreshold,
+    };
+
+    previousThreshold = threshold;
+
+    return range;
+  });
+}
+
+export function getProgressState(
+  progress: number,
+  thresholds: number[],
+  index: number,
+): LoadingState {
+  const activeIndex = thresholds.findIndex((threshold) => progress < threshold);
+
+  if (activeIndex === -1) {
+    return 'done';
+  }
+
+  if (index < activeIndex) {
+    return 'done';
+  }
+
+  if (index === activeIndex) {
+    return 'active';
+  }
+
+  return 'pending';
+}
+
+export function resolveLocalProgress(progress: number, range: ProgressRange) {
+  const rangeSize = Math.max(range.end - range.start, 1);
+  const clampedProgress = Math.min(Math.max(progress, range.start), range.end);
+
+  return ((clampedProgress - range.start) / rangeSize) * MAX_PROGRESS;
+}

--- a/src/pages/Loading/loadingScenario.ts
+++ b/src/pages/Loading/loadingScenario.ts
@@ -1,0 +1,231 @@
+import type {
+  LoadingCaseNumber,
+  LoadingDetailStep,
+  LoadingStep,
+  LoadingStepId,
+} from './types/loadingPage.types';
+
+type LoadingStepOverride = Partial<Omit<LoadingStep, 'id'>>;
+
+const aiAnalysisDetailSteps: LoadingDetailStep[] = [
+  {
+    title: '리다이렉트 경로 분석',
+    weight: 26,
+  },
+  {
+    title: '글로벌 보안 DB 대조',
+    weight: 24,
+  },
+  {
+    title: '도메인 사칭 분석',
+    weight: 25,
+  },
+  {
+    title: '서버 및 인증서 검사',
+    weight: 25,
+  },
+];
+
+const loadingStepMap: Record<LoadingStepId, LoadingStep> = {
+  aiAnalysis: {
+    activeDescription: '딥러닝 엔진이 위험 요소를 탐지하고 있습니다...',
+    details: aiAnalysisDetailSteps,
+    doneDescription: 'AI 위험 분석이 완료되었습니다.',
+    id: 'aiAnalysis',
+    pendingDescription: 'AI 위험 분석을 준비하고 있습니다...',
+    title: 'AI 위험 분석',
+    weight: 18,
+  },
+  completed: {
+    activeDescription: '분석 결과를 정리하고 결과 페이지로 이동할 준비를 하고 있습니다...',
+    doneDescription: '분석이 완료되었습니다. 결과 페이지로 이동합니다.',
+    id: 'completed',
+    pendingDescription: '최종 결과 정리를 준비하고 있습니다...',
+    title: '분석 완료',
+    weight: 8,
+  },
+  decode: {
+    activeDescription: 'QR 코드의 실제 대상 URL을 읽어오고 있습니다...',
+    doneDescription: 'QR 코드 디코딩이 완료되었습니다.',
+    id: 'decode',
+    pendingDescription: 'QR 코드 디코딩을 준비하고 있습니다...',
+    title: 'QR 디코딩',
+    weight: 14,
+  },
+  externalApi: {
+    activeDescription: '외부 보안 API에서 위협 및 평판 정보를 조회하고 있습니다...',
+    doneDescription: '외부 API 조회가 완료되었습니다.',
+    id: 'externalApi',
+    pendingDescription: '외부 API 조회를 준비하고 있습니다...',
+    title: '외부 API 조회',
+    weight: 12,
+  },
+  internalDb: {
+    activeDescription: '내부 DB에서 기존 분석 이력과 수집 데이터를 조회하고 있습니다...',
+    doneDescription: '내부 DB 조회가 완료되었습니다.',
+    id: 'internalDb',
+    pendingDescription: '내부 DB 조회를 준비하고 있습니다...',
+    title: '내부 DB 조회',
+    weight: 12,
+  },
+  redirect: {
+    activeDescription: '단축 URL 또는 중간 경유 경로를 추적하고 있습니다...',
+    doneDescription: '리다이렉션 추적이 완료되었습니다.',
+    id: 'redirect',
+    pendingDescription: '리다이렉션 추적을 준비하고 있습니다...',
+    title: '리다이렉션 추적',
+    weight: 14,
+  },
+  report: {
+    activeDescription: '상세 분석 리포트를 작성하고 있습니다...',
+    doneDescription: '리포트 작성이 완료되었습니다.',
+    id: 'report',
+    pendingDescription: '리포트 작성을 준비하고 있습니다...',
+    title: '리포트 작성',
+    weight: 10,
+  },
+  riskScore: {
+    activeDescription: '분석 결과를 바탕으로 종합 위험도를 산출하고 있습니다...',
+    doneDescription: '종합 위험도 산출이 완료되었습니다.',
+    id: 'riskScore',
+    pendingDescription: '종합 위험도 산출을 준비하고 있습니다...',
+    title: '종합 위험도 산출',
+    weight: 12,
+  },
+  shortUrlCheck: {
+    activeDescription: '단축 URL 여부를 확인하고 있습니다...',
+    doneDescription: '단축 URL이 확인되었습니다.',
+    id: 'shortUrlCheck',
+    pendingDescription: '단축 URL 여부 확인을 준비하고 있습니다...',
+    title: '단축 URL 여부 확인',
+    weight: 8,
+  },
+};
+
+const loadingCaseStepOrder: Record<LoadingCaseNumber, LoadingStepId[]> = {
+  1: ['decode', 'shortUrlCheck', 'redirect', 'internalDb', 'riskScore', 'report', 'completed'],
+  2: [
+    'decode',
+    'shortUrlCheck',
+    'redirect',
+    'internalDb',
+    'aiAnalysis',
+    'riskScore',
+    'report',
+    'completed',
+  ],
+  3: [
+    'decode',
+    'shortUrlCheck',
+    'redirect',
+    'internalDb',
+    'externalApi',
+    'aiAnalysis',
+    'riskScore',
+    'report',
+    'completed',
+  ],
+  4: ['decode', 'internalDb', 'riskScore', 'report', 'completed'],
+  5: ['decode', 'internalDb', 'aiAnalysis', 'redirect', 'riskScore', 'report', 'completed'],
+  6: [
+    'decode',
+    'internalDb',
+    'externalApi',
+    'aiAnalysis',
+    'redirect',
+    'riskScore',
+    'report',
+    'completed',
+  ],
+  7: ['decode', 'externalApi', 'completed'],
+  8: ['decode', 'completed'],
+};
+
+const loadingCaseStepOverrides: Record<
+  LoadingCaseNumber,
+  Partial<Record<LoadingStepId, LoadingStepOverride>>
+> = {
+  1: {
+    internalDb: {
+      doneDescription: '분석 이력이 확인되어 저장된 결과를 그대로 사용합니다.',
+    },
+    shortUrlCheck: {
+      doneDescription: '단축 URL이 확인되어 리다이렉션 추적으로 이동합니다.',
+    },
+  },
+  2: {
+    internalDb: {
+      doneDescription: '분석 이력은 없지만 수집된 데이터가 있어 AI 분석을 이어갑니다.',
+    },
+    shortUrlCheck: {
+      doneDescription: '단축 URL이 확인되어 리다이렉션 추적으로 이동합니다.',
+    },
+  },
+  3: {
+    externalApi: {
+      doneDescription: '외부 API 조회가 완료되어 AI 위험 분석으로 이동합니다.',
+    },
+    internalDb: {
+      doneDescription: '내부 DB에 분석 데이터가 없어 외부 API 조회를 진행합니다.',
+    },
+    shortUrlCheck: {
+      doneDescription: '단축 URL이 확인되어 리다이렉션 추적으로 이동합니다.',
+    },
+  },
+  4: {
+    internalDb: {
+      doneDescription: '분석 이력이 확인되어 저장된 결과를 그대로 사용합니다.',
+    },
+  },
+  5: {
+    internalDb: {
+      doneDescription: '수집 데이터가 확인되어 AI 위험 분석을 진행합니다.',
+    },
+  },
+  6: {
+    externalApi: {
+      doneDescription: '외부 API 조회가 완료되어 AI 위험 분석으로 이동합니다.',
+    },
+    internalDb: {
+      doneDescription: '내부 DB만으로는 부족하여 외부 API 조회를 진행합니다.',
+    },
+  },
+  7: {
+    completed: {
+      activeDescription: '안전 판정이 확인되어 결과 페이지로 이동하고 있습니다...',
+      doneDescription: '외부 API에서 안전으로 판정되어 분석을 종료했습니다.',
+    },
+    externalApi: {
+      doneDescription: '외부 API에서 안전 결과가 확인되어 추가 분석 없이 종료합니다.',
+    },
+  },
+  8: {
+    completed: {
+      activeDescription: 'URL 형식이 아닌 QR 코드로 확인되어 분석을 종료하고 있습니다...',
+      doneDescription: 'URL 형식이 아닌 QR 코드로 확인되어 분석을 종료했습니다.',
+    },
+    decode: {
+      doneDescription: 'QR 코드 내용을 확인한 결과 URL 형식이 아니었습니다.',
+    },
+  },
+};
+
+export function getLoadingSteps(caseNumber: LoadingCaseNumber): LoadingStep[] {
+  const stepOverrides = loadingCaseStepOverrides[caseNumber];
+
+  return loadingCaseStepOrder[caseNumber].map((stepId) => {
+    const step = loadingStepMap[stepId];
+    const override = stepOverrides?.[stepId];
+    const resolvedDetails = override?.details ?? step.details;
+
+    return {
+      ...step,
+      ...override,
+      details: resolvedDetails ? [...resolvedDetails] : undefined,
+    };
+  });
+}
+
+export function isLoadingCaseNumber(value: number): value is LoadingCaseNumber {
+  return Number.isInteger(value) && value >= 1 && value <= 8;
+}

--- a/src/pages/Loading/styles/loadingPage.css.ts
+++ b/src/pages/Loading/styles/loadingPage.css.ts
@@ -111,6 +111,92 @@ export const flowSection = style({
   gap: vars.spacing.md,
 });
 
+export const caseControlSection = style({
+  display: 'grid',
+  gap: vars.spacing.md,
+  paddingTop: vars.spacing.sm,
+  borderTop: `1px solid ${vars.colors.border}`,
+});
+
+export const caseControlHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: vars.spacing.sm,
+  flexWrap: 'wrap',
+});
+
+export const caseControlTitle = style({
+  margin: 0,
+  color: vars.colors.black,
+  fontSize: vars.font.size.lg,
+  fontWeight: vars.font.weight.semibold,
+});
+
+export const caseControlCurrent = style({
+  margin: 0,
+  color: vars.colors.subText,
+  fontSize: vars.font.size.sm,
+  fontWeight: vars.font.weight.medium,
+});
+
+export const caseButtonList = style({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fit, minmax(92px, 1fr))',
+  gap: vars.spacing.sm,
+});
+
+export const caseButton = style({
+  minHeight: '44px',
+  border: `1px solid ${vars.colors.border}`,
+  borderRadius: vars.radius.md,
+  backgroundColor: vars.colors.white,
+  color: vars.colors.black,
+  fontSize: vars.font.size.sm,
+  fontWeight: vars.font.weight.semibold,
+  cursor: 'pointer',
+  transition: 'background-color 160ms ease, border-color 160ms ease, color 160ms ease',
+  selectors: {
+    '&:hover': {
+      borderColor: vars.colors.mainBorder,
+      backgroundColor: vars.colors.mainXLight,
+    },
+  },
+});
+
+export const caseButtonActive = style({
+  borderColor: vars.colors.main,
+  backgroundColor: vars.colors.main,
+  color: vars.colors.white,
+});
+
+export const randomCaseButton = style({
+  borderColor: vars.colors.success,
+  color: vars.colors.success,
+  selectors: {
+    '&:hover': {
+      borderColor: vars.colors.success,
+      backgroundColor: 'rgba(34, 197, 94, 0.08)',
+    },
+  },
+});
+
+export const branchDemoButton = style({
+  borderColor: vars.colors.black,
+  color: vars.colors.black,
+  selectors: {
+    '&:hover': {
+      borderColor: vars.colors.black,
+      backgroundColor: vars.colors.sub,
+    },
+  },
+});
+
+export const branchDemoButtonActive = style({
+  backgroundColor: vars.colors.black,
+  color: vars.colors.white,
+});
+
 export const flowList = style({
   margin: 0,
   padding: 0,
@@ -243,8 +329,6 @@ export const detailIcon = style({
   display: 'inline-flex',
   alignItems: 'center',
   justifyContent: 'center',
-  fontSize: vars.font.size.xs,
-  fontWeight: vars.font.weight.bold,
 });
 
 export const detailIconImage = style({

--- a/src/pages/Loading/types/loadingPage.types.ts
+++ b/src/pages/Loading/types/loadingPage.types.ts
@@ -1,0 +1,38 @@
+export type LoadingCaseNumber = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+
+export type LoadingStepId =
+  | 'decode'
+  | 'shortUrlCheck'
+  | 'redirect'
+  | 'internalDb'
+  | 'externalApi'
+  | 'aiAnalysis'
+  | 'riskScore'
+  | 'report'
+  | 'completed';
+
+export type LoadingDetailStep = {
+  title: string;
+  weight: number;
+};
+
+export type LoadingStep = {
+  activeDescription: string;
+  details?: LoadingDetailStep[];
+  doneDescription: string;
+  id: LoadingStepId;
+  pendingDescription: string;
+  title: string;
+  weight: number;
+};
+
+export type LoadingRevealMode = 'full' | 'sequential';
+
+export type LoadingPageData = {
+  caseNumber: LoadingCaseNumber;
+  progressIntervalMs: number;
+  revealMode: LoadingRevealMode;
+  steps: LoadingStep[];
+};
+
+export type LoadingState = 'active' | 'done' | 'pending';

--- a/src/pages/Report/ReportPage.tsx
+++ b/src/pages/Report/ReportPage.tsx
@@ -15,8 +15,8 @@ export default function ReportPage() {
           <h2>{section.title}</h2>
           <p>{section.summary}</p>
           <ul>
-            {section.items.map((item) => (
-              <li key={item}>{item}</li>
+            {section.items.map((item, index) => (
+              <li key={`${section.id}-${item}-${index}`}>{item}</li>
             ))}
           </ul>
         </section>

--- a/src/pages/Report/ReportPage.tsx
+++ b/src/pages/Report/ReportPage.tsx
@@ -1,8 +1,26 @@
+import { useReportPage } from './hooks/useReportPage';
+
 export default function ReportPage() {
+  const { reportPageData } = useReportPage();
+
   return (
     <main>
-      <h1>상세 보고서 페이지</h1>
-      <p>위험 요소, 대응 지침, 추가 가이드를 제공하는 상세 보고서 페이지입니다.</p>
+      <h1>{reportPageData.reportTitle}</h1>
+      <p>분석 대상: {reportPageData.scannedUrl}</p>
+      <p>분석 시각: {reportPageData.scannedAt}</p>
+      <p>위험 수준: {reportPageData.riskLevel}</p>
+
+      {reportPageData.sections.map((section) => (
+        <section key={section.id}>
+          <h2>{section.title}</h2>
+          <p>{section.summary}</p>
+          <ul>
+            {section.items.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </section>
+      ))}
     </main>
   );
 }

--- a/src/pages/Report/api/fetchReportPageData.ts
+++ b/src/pages/Report/api/fetchReportPageData.ts
@@ -1,0 +1,43 @@
+import type { ReportPageData } from '../types/reportPage.types';
+
+export const mockReportPageData: ReportPageData = {
+  reportTitle: '상세 분석 리포트',
+  riskLevel: 'warning',
+  scannedAt: '2026-03-14 14:10',
+  scannedUrl: 'https://www.example-warning-site.com',
+  sections: [
+    {
+      id: 'summary',
+      items: ['리다이렉션이 2회 감지되었습니다.', '도메인 생성일이 짧아 추가 검토가 필요합니다.'],
+      summary: '분석 결과, 주의가 필요한 정황이 확인되었습니다.',
+      title: '요약',
+    },
+    {
+      id: 'domain',
+      items: [
+        'WHOIS 생성일: 2025-12-01',
+        'SSL 인증서 유효 기간이 짧습니다.',
+        '유사 도메인 패턴이 일부 감지되었습니다.',
+      ],
+      summary: '도메인 및 인증서 정보 기준으로 위험 신호를 정리했습니다.',
+      title: '도메인 분석',
+    },
+    {
+      id: 'response',
+      items: [
+        '즉시 개인정보 입력을 요구하지 마세요.',
+        '공식 사이트 주소와 일치하는지 교차 확인하세요.',
+      ],
+      summary: '사용자가 바로 취할 수 있는 대응 가이드입니다.',
+      title: '대응 가이드',
+    },
+  ],
+};
+
+export async function fetchReportPageData(): Promise<ReportPageData> {
+  return Promise.resolve(mockReportPageData);
+}
+
+export function getInitialReportPageData(): ReportPageData {
+  return mockReportPageData;
+}

--- a/src/pages/Report/hooks/useReportPage.ts
+++ b/src/pages/Report/hooks/useReportPage.ts
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+import { fetchReportPageData, getInitialReportPageData } from '../api/fetchReportPageData';
+
+import type { ReportPageData } from '../types/reportPage.types';
+
+type UseReportPageReturn = {
+  reportPageData: ReportPageData;
+};
+
+export function useReportPage(): UseReportPageReturn {
+  const [reportPageData, setReportPageData] = useState<ReportPageData>(getInitialReportPageData);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadReportPageData = async () => {
+      const response = await fetchReportPageData();
+
+      if (isMounted) {
+        setReportPageData(response);
+      }
+    };
+
+    void loadReportPageData();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return {
+    reportPageData,
+  };
+}

--- a/src/pages/Report/types/reportPage.types.ts
+++ b/src/pages/Report/types/reportPage.types.ts
@@ -1,0 +1,14 @@
+export type ReportSection = {
+  id: string;
+  items: string[];
+  summary: string;
+  title: string;
+};
+
+export type ReportPageData = {
+  reportTitle: string;
+  riskLevel: 'safe' | 'warning' | 'critical';
+  scannedAt: string;
+  scannedUrl: string;
+  sections: ReportSection[];
+};

--- a/src/pages/ResultCritical/api/fetchResultCriticalPageData.ts
+++ b/src/pages/ResultCritical/api/fetchResultCriticalPageData.ts
@@ -12,3 +12,7 @@ export async function fetchResultCriticalPageData(): Promise<ResultCriticalPageD
   // TODO: Replace this mock return with real API integration.
   return Promise.resolve(mockResultCriticalPageData);
 }
+
+export function getInitialResultCriticalPageData(): ResultCriticalPageData {
+  return mockResultCriticalPageData;
+}

--- a/src/pages/ResultCritical/hooks/useResultCriticalPage.ts
+++ b/src/pages/ResultCritical/hooks/useResultCriticalPage.ts
@@ -6,7 +6,7 @@ import { shareCurrentPage } from '@/shared/lib/browser/shareCurrentPage';
 
 import {
   fetchResultCriticalPageData,
-  mockResultCriticalPageData,
+  getInitialResultCriticalPageData,
 } from '../api/fetchResultCriticalPageData';
 
 import type { ResultCriticalPageData } from '../types/resultCriticalPage.types';
@@ -25,7 +25,7 @@ export function useResultCriticalPage(): UseResultCriticalPageReturn {
   const { message, modal } = App.useApp();
   const navigate = useNavigate();
   const [resultCriticalData, setResultCriticalData] = useState<ResultCriticalPageData>(
-    mockResultCriticalPageData,
+    getInitialResultCriticalPageData,
   );
   const [isReportOpen, setIsReportOpen] = useState(false);
 

--- a/src/pages/ResultWarning/api/fetchResultWarningPageData.ts
+++ b/src/pages/ResultWarning/api/fetchResultWarningPageData.ts
@@ -12,3 +12,7 @@ export async function fetchResultWarningPageData(): Promise<ResultWarningPageDat
   // TODO: Replace this mock return with real API integration.
   return Promise.resolve(mockResultWarningPageData);
 }
+
+export function getInitialResultWarningPageData(): ResultWarningPageData {
+  return mockResultWarningPageData;
+}

--- a/src/pages/ResultWarning/hooks/useResultWarningPage.ts
+++ b/src/pages/ResultWarning/hooks/useResultWarningPage.ts
@@ -7,7 +7,7 @@ import { shareCurrentPage } from '@/shared/lib/browser/shareCurrentPage';
 
 import {
   fetchResultWarningPageData,
-  mockResultWarningPageData,
+  getInitialResultWarningPageData,
 } from '../api/fetchResultWarningPageData';
 
 import type { ResultWarningPageData } from '../types/resultWarningPage.types';
@@ -24,8 +24,9 @@ type UseResultWarningPageReturn = {
 export function useResultWarningPage(): UseResultWarningPageReturn {
   const { modal } = App.useApp();
   const navigate = useNavigate();
-  const [resultWarningData, setResultWarningData] =
-    useState<ResultWarningPageData>(mockResultWarningPageData);
+  const [resultWarningData, setResultWarningData] = useState<ResultWarningPageData>(
+    getInitialResultWarningPageData,
+  );
   const [isReportOpen, setIsReportOpen] = useState(false);
 
   useEffect(() => {

--- a/src/pages/ScanHistory/ScanHistoryPage.tsx
+++ b/src/pages/ScanHistory/ScanHistoryPage.tsx
@@ -1,8 +1,23 @@
+import { useScanHistoryPage } from './hooks/useScanHistoryPage';
+
 export default function ScanHistoryPage() {
+  const { scanHistoryPageData } = useScanHistoryPage();
+
   return (
     <main>
       <h1>스캔 이력 목록</h1>
-      <p>최근 스캔 내역과 상태 배지를 표시하는 스캔 이력 목록 페이지입니다.</p>
+      <p>최근 스캔 내역과 상태를 기준으로 백엔드 연동 전 mock 데이터를 보여줍니다.</p>
+
+      <ul>
+        {scanHistoryPageData.items.map((item) => (
+          <li key={item.id}>
+            <strong>{item.title}</strong>
+            <p>{item.url}</p>
+            <p>분석 시각: {item.scannedAt}</p>
+            <p>상태: {item.status}</p>
+          </li>
+        ))}
+      </ul>
     </main>
   );
 }

--- a/src/pages/ScanHistory/api/fetchScanHistoryPageData.ts
+++ b/src/pages/ScanHistory/api/fetchScanHistoryPageData.ts
@@ -1,0 +1,35 @@
+import type { ScanHistoryPageData } from '../types/scanHistoryPage.types';
+
+export const mockScanHistoryPageData: ScanHistoryPageData = {
+  items: [
+    {
+      id: 'scan-1',
+      scannedAt: '2026-03-14 13:40',
+      status: 'safe',
+      title: '공식 이벤트 안내 페이지',
+      url: 'https://www.example-safe-site.com',
+    },
+    {
+      id: 'scan-2',
+      scannedAt: '2026-03-14 12:10',
+      status: 'warning',
+      title: '주의가 필요한 리다이렉트 페이지',
+      url: 'https://www.example-warning-site.com',
+    },
+    {
+      id: 'scan-3',
+      scannedAt: '2026-03-14 09:55',
+      status: 'critical',
+      title: '악성 코드 의심 페이지',
+      url: 'https://www.example-critical-site.com',
+    },
+  ],
+};
+
+export async function fetchScanHistoryPageData(): Promise<ScanHistoryPageData> {
+  return Promise.resolve(mockScanHistoryPageData);
+}
+
+export function getInitialScanHistoryPageData(): ScanHistoryPageData {
+  return mockScanHistoryPageData;
+}

--- a/src/pages/ScanHistory/hooks/useScanHistoryPage.ts
+++ b/src/pages/ScanHistory/hooks/useScanHistoryPage.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+
+import {
+  fetchScanHistoryPageData,
+  getInitialScanHistoryPageData,
+} from '../api/fetchScanHistoryPageData';
+
+import type { ScanHistoryPageData } from '../types/scanHistoryPage.types';
+
+type UseScanHistoryPageReturn = {
+  scanHistoryPageData: ScanHistoryPageData;
+};
+
+export function useScanHistoryPage(): UseScanHistoryPageReturn {
+  const [scanHistoryPageData, setScanHistoryPageData] = useState<ScanHistoryPageData>(
+    getInitialScanHistoryPageData,
+  );
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadScanHistoryPageData = async () => {
+      const response = await fetchScanHistoryPageData();
+
+      if (isMounted) {
+        setScanHistoryPageData(response);
+      }
+    };
+
+    void loadScanHistoryPageData();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return {
+    scanHistoryPageData,
+  };
+}

--- a/src/pages/ScanHistory/types/scanHistoryPage.types.ts
+++ b/src/pages/ScanHistory/types/scanHistoryPage.types.ts
@@ -1,0 +1,13 @@
+export type ScanHistoryStatus = 'safe' | 'warning' | 'critical';
+
+export type ScanHistoryItem = {
+  id: string;
+  scannedAt: string;
+  title: string;
+  url: string;
+  status: ScanHistoryStatus;
+};
+
+export type ScanHistoryPageData = {
+  items: ScanHistoryItem[];
+};


### PR DESCRIPTION
## Summary

#12 

로딩 화면 분기에 따른 ui 변경 및 각 페이지 별 연동 준비 

## Tasks

  * 로딩 화면에 테스트 케이스 선택 및 무작위 선택 기능 추가
  * 순차 데모 모드로 단계별 로딩 흐름 시각화
  * 리포트 페이지에 동적 콘텐츠 및 섹션 기반 레이아웃 구현
  * 스캔 기록 페이지에 항목별 상세 정보(URL, 스캔 시간, 상태) 표시

* **개선**
  * 로딩 단계를 정적 정의에서 데이터 기반 동적 흐름으로 변경
  * 리포트 및 스캔 기록 데이터 로딩 방식 개선

## Screenshot
로딩 분기 별로 생성 예시 구현 
<img width="1090" height="1162" alt="image" src="https://github.com/user-attachments/assets/0f53bbc9-3a72-44ee-874c-bec8834eb84a" />



