### PR TITLE
[KD-42] QR 디코딩 결과 비URL일 경우에 따른 UI

### DIFF
--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -8,6 +8,7 @@ const routeLinks = [
   { to: '/report', label: '/report' },
   { to: '/scan-history', label: '/scan-history' },
   { to: '/result/critical', label: '/result/critical' },
+  { to: '/result/non-url', label: '/result/non-url' },
   { to: '/result/safe', label: '/result/safe' },
   { to: '/result/warning', label: '/result/warning' },
 ] as const;

--- a/src/pages/ResultCritical/ui/ResultCriticalHero.tsx
+++ b/src/pages/ResultCritical/ui/ResultCriticalHero.tsx
@@ -1,26 +1,11 @@
-import { statusMarkIconByTone } from '@/shared/icon/resultIcons';
-
-import * as styles from '../styles/resultCriticalPage.css';
+import ResultHero from '@/shared/ui/resultHero';
 
 export default function ResultCriticalHero() {
   return (
-    <header className={styles.hero}>
-      <div className={styles.statusHalo}>
-        <img
-          alt=""
-          aria-hidden
-          className={styles.statusBadge}
-          src={statusMarkIconByTone.critical}
-        />
-      </div>
-
-      <h1 className={styles.heroTitle}>
-        위험! 악성 코드가 감지되어 접속을 권장하지 않는 사이트입니다.
-      </h1>
-
-      <p className={styles.heroDescription}>
-        Veri-Q 분석 결과, 해당 QR 코드는 악성 위험 사이트로 분류되었습니다.
-      </p>
-    </header>
+    <ResultHero
+      description="Veri-Q 분석 결과, 해당 QR 코드는 악성 위험 사이트로 분류되었습니다."
+      title="위험! 악성 코드가 감지되어 접속을 권장하지 않는 사이트입니다."
+      tone="critical"
+    />
   );
 }

--- a/src/pages/ResultNonUrl/ResultNonUrlPage.tsx
+++ b/src/pages/ResultNonUrl/ResultNonUrlPage.tsx
@@ -81,7 +81,9 @@ export default function ResultNonUrlPage() {
             </button>
 
             {executionFeedbackMessage ? (
-              <p className={styles.executionFeedback}>{executionFeedbackMessage}</p>
+              <p aria-live="polite" className={styles.executionFeedback} role="status">
+                {executionFeedbackMessage}
+              </p>
             ) : null}
 
             <ResultActionButtons
@@ -97,6 +99,7 @@ export default function ResultNonUrlPage() {
               <div className={styles.previewButtonList}>
                 {nonUrlActionPreviewItems.map((previewItem) => (
                   <button
+                    aria-pressed={displayedActionType === previewItem.actionType}
                     className={`${styles.previewButton} ${
                       displayedActionType === previewItem.actionType
                         ? styles.previewButtonActive

--- a/src/pages/ResultNonUrl/ResultNonUrlPage.tsx
+++ b/src/pages/ResultNonUrl/ResultNonUrlPage.tsx
@@ -1,0 +1,122 @@
+import { useMemo, useState } from 'react';
+
+import { ResultActionButtons } from '@/shared/component';
+import { qrIconByTone } from '@/shared/icon/resultIcons';
+import { openExternalLink } from '@/shared/lib/browser/openExternalLink';
+import AppHeader from '@/shared/ui/app-header';
+import ResultHero from '@/shared/ui/resultHero';
+
+import { nonUrlActionPreviewItems } from './constants/nonUrlActionCatalog';
+import { useResultNonUrlPage } from './hooks/useResultNonUrlPage';
+import { resolveNonUrlActionExecution } from './lib/resolveNonUrlActionExecution';
+import * as styles from './styles/resultNonUrlPage.css';
+import DetectedNonUrlActionSection from './ui/DetectedNonUrlActionSection';
+import * as warningStyles from '../ResultWarning/styles/resultWarningPage.css';
+
+import type { NonUrlActionType } from './types/resultNonUrlPage.types';
+
+export default function ResultNonUrlPage() {
+  const { handleRescan, handleShareResult, resultNonUrlPageData } = useResultNonUrlPage();
+  const [selectedPreviewActionType, setSelectedPreviewActionType] =
+    useState<NonUrlActionType | null>(null);
+  const [executionFeedbackMessage, setExecutionFeedbackMessage] = useState<string | null>(null);
+
+  const selectedPreviewItem = useMemo(
+    () =>
+      selectedPreviewActionType
+        ? (nonUrlActionPreviewItems.find((item) => item.actionType === selectedPreviewActionType) ??
+          null)
+        : null,
+    [selectedPreviewActionType],
+  );
+
+  const displayedActionType =
+    selectedPreviewItem?.actionType ?? resultNonUrlPageData.detectedActionType;
+  const displayedTargetValue =
+    selectedPreviewItem?.sampleTargetValue ?? resultNonUrlPageData.targetValue;
+
+  const handleExecuteAction = () => {
+    const executionPlan = resolveNonUrlActionExecution(displayedActionType, displayedTargetValue);
+    setExecutionFeedbackMessage(executionPlan.message);
+
+    if (executionPlan.kind === 'open') {
+      openExternalLink(executionPlan.url);
+      return;
+    }
+
+    if (executionPlan.kind === 'navigate') {
+      window.location.href = executionPlan.href;
+    }
+  };
+
+  return (
+    <main className={warningStyles.page}>
+      <AppHeader iconSrc={qrIconByTone.warning} />
+
+      <div className={warningStyles.shell}>
+        <section className={warningStyles.content}>
+          <ResultHero
+            description="Veri-Q 분석 결과, 해당 QR 코드는 비 URL로 분류되었습니다."
+            title={
+              <>
+                주의하세요!
+                <br />
+                URL이 아닌 어떠한 것이 실행되는 것이에요!
+              </>
+            }
+            tone="warning"
+          />
+
+          <section className={styles.futureContent}>
+            <DetectedNonUrlActionSection
+              actionType={displayedActionType}
+              sectionDescription={resultNonUrlPageData.sectionDescription}
+              sectionNumber={resultNonUrlPageData.sectionNumber}
+              sectionTitle={resultNonUrlPageData.sectionTitle}
+              targetValue={displayedTargetValue}
+            />
+
+            <button className={styles.executionButton} onClick={handleExecuteAction} type="button">
+              주의하여 실행하기
+            </button>
+
+            {executionFeedbackMessage ? (
+              <p className={styles.executionFeedback}>{executionFeedbackMessage}</p>
+            ) : null}
+
+            <ResultActionButtons
+              onRescanClick={handleRescan}
+              onShareClick={() => {
+                void handleShareResult();
+              }}
+            />
+
+            <section className={styles.previewSection}>
+              <h2 className={styles.previewTitle}>모든 비 URL 경우의 수 보기</h2>
+
+              <div className={styles.previewButtonList}>
+                {nonUrlActionPreviewItems.map((previewItem) => (
+                  <button
+                    className={`${styles.previewButton} ${
+                      displayedActionType === previewItem.actionType
+                        ? styles.previewButtonActive
+                        : ''
+                    }`}
+                    key={previewItem.actionType}
+                    onClick={() => {
+                      setSelectedPreviewActionType(previewItem.actionType);
+                      setExecutionFeedbackMessage(null);
+                    }}
+                    type="button"
+                  >
+                    {previewItem.label}
+                  </button>
+                ))}
+              </div>
+            </section>
+          </section>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/pages/ResultNonUrl/api/fetchResultNonUrlPageData.ts
+++ b/src/pages/ResultNonUrl/api/fetchResultNonUrlPageData.ts
@@ -1,0 +1,17 @@
+import type { ResultNonUrlPageData } from '../types/resultNonUrlPage.types';
+
+export const mockResultNonUrlPageData: ResultNonUrlPageData = {
+  detectedActionType: 'telSms',
+  sectionDescription: '백엔드에서 전달한 실행 유형 상세 설명과 주의사항을 표시합니다.',
+  sectionNumber: '1',
+  sectionTitle: '탐지된 비 URL 유형 분석',
+  targetValue: '010-1234-5678',
+};
+
+export async function fetchResultNonUrlPageData(): Promise<ResultNonUrlPageData> {
+  return Promise.resolve(mockResultNonUrlPageData);
+}
+
+export function getInitialResultNonUrlPageData(): ResultNonUrlPageData {
+  return mockResultNonUrlPageData;
+}

--- a/src/pages/ResultNonUrl/api/fetchResultNonUrlPageData.ts
+++ b/src/pages/ResultNonUrl/api/fetchResultNonUrlPageData.ts
@@ -9,9 +9,9 @@ export const mockResultNonUrlPageData: ResultNonUrlPageData = {
 };
 
 export async function fetchResultNonUrlPageData(): Promise<ResultNonUrlPageData> {
-  return Promise.resolve(mockResultNonUrlPageData);
+  return Promise.resolve({ ...mockResultNonUrlPageData });
 }
 
 export function getInitialResultNonUrlPageData(): ResultNonUrlPageData {
-  return mockResultNonUrlPageData;
+  return { ...mockResultNonUrlPageData };
 }

--- a/src/pages/ResultNonUrl/constants/nonUrlActionCatalog.ts
+++ b/src/pages/ResultNonUrl/constants/nonUrlActionCatalog.ts
@@ -1,0 +1,117 @@
+import type { NonUrlActionType } from '../types/resultNonUrlPage.types';
+
+type NonUrlActionCatalogItem = {
+  buildDescription: (targetValue?: string) => string;
+  caution: string;
+  englishLabel: string;
+  previewLabel: string;
+  sampleTargetValue?: string;
+  title: string;
+};
+
+export type NonUrlActionPreviewItem = {
+  actionType: NonUrlActionType;
+  label: string;
+  sampleTargetValue?: string;
+};
+
+export type ResolvedNonUrlActionContent = {
+  caution: string;
+  description: string;
+  englishLabel: string;
+  title: string;
+};
+
+const nonUrlActionCatalog: Record<NonUrlActionType, NonUrlActionCatalogItem> = {
+  appLaunch: {
+    buildDescription: (targetValue) =>
+      targetValue
+        ? `"${targetValue}" 앱을 바로 실행하려는 QR 코드입니다. 앱이 설치되어 있으면 즉시 열리고, 설치되어 있지 않으면 연결 가능한 앱 선택 화면으로 이동할 수 있습니다.`
+        : '특정 앱을 바로 실행하려는 QR 코드입니다. 설치된 앱을 호출해 화면 전환이나 특정 작업을 유도할 수 있습니다.',
+    caution:
+      '예상하지 못한 앱 실행은 금융 앱 이동, 인증 화면 호출, 악성 앱 연계 등으로 이어질 수 있으므로 사용자가 의도한 동작인지 먼저 확인해야 합니다.',
+    englishLabel: 'APP LAUNCH INTENT',
+    previewLabel: '앱 실행',
+    sampleTargetValue: 'KakaoTalk',
+    title: '앱 실행 감지',
+  },
+  appStore: {
+    buildDescription: (targetValue) =>
+      targetValue
+        ? `"${targetValue}" 앱 설치 페이지로 이동하려는 QR 코드입니다. 사용자를 앱 스토어로 보내 설치 또는 업데이트를 유도할 수 있습니다.`
+        : '앱 스토어 설치 페이지로 이동하려는 QR 코드입니다. 특정 앱 다운로드나 업데이트를 유도하는 동작입니다.',
+    caution:
+      '출처가 불명확한 설치 유도는 가짜 앱, 악성 앱, 과도한 권한 요청으로 이어질 수 있으므로 앱 이름과 개발사를 반드시 대조해야 합니다.',
+    englishLabel: 'APP STORE INTENT',
+    previewLabel: '앱 스토어',
+    sampleTargetValue: 'Veri-Q Secure',
+    title: '앱 스토어 이동 감지',
+  },
+  bitcoin: {
+    buildDescription: (targetValue) =>
+      targetValue
+        ? `비트코인 지갑 주소 "${targetValue}"를 확인하거나 송금을 유도하는 QR 코드입니다. 결제 화면 또는 지갑 앱으로 연결될 수 있습니다.`
+        : '비트코인 지갑 주소를 확인하거나 송금을 유도하는 QR 코드입니다. 가상자산 결제 또는 지갑 앱 호출이 목적일 수 있습니다.',
+    caution:
+      '코인 지갑 주소는 한번 송금하면 되돌리기 어렵습니다. 주소 위변조나 사기 결제 유도 가능성이 있으므로 발신자와 결제 맥락을 먼저 검증해야 합니다.',
+    englishLabel: 'BITCOIN WALLET',
+    previewLabel: '비트코인',
+    sampleTargetValue: 'bc1q8s7examplewallet9xy2k',
+    title: '비트코인 지갑 감지',
+  },
+  telSms: {
+    buildDescription: (targetValue) =>
+      targetValue
+        ? `"${targetValue}"로 전화 또는 문자 앱을 실행하려는 QR 코드입니다. 탭 한 번으로 발신이나 문자 작성 화면이 열릴 수 있습니다.`
+        : '특정 번호로 전화 또는 문자 앱을 실행하려는 QR 코드입니다. 사용자를 통화나 메시지 발신 화면으로 바로 이동시킬 수 있습니다.',
+    caution:
+      '의도하지 않은 통화나 문자 발신은 프리미엄 요금 번호 연결, 스미싱 링크 응답, 개인정보 노출로 이어질 수 있으므로 번호를 먼저 확인해야 합니다.',
+    englishLabel: 'TEL / SMS ACTION',
+    previewLabel: '전화/문자',
+    sampleTargetValue: '010-1234-5678',
+    title: '전화·문자 실행 감지',
+  },
+  unknown: {
+    buildDescription: () =>
+      'QR 코드 내부에 실행 동작이 포함되어 있지만, 현재 분석 정보만으로는 정확히 어떤 행동이 수행되는지 식별되지 않았습니다.',
+    caution:
+      '동작을 명확히 알 수 없는 QR 코드는 예기치 않은 페이지 이동, 앱 호출, 파일 실행으로 이어질 수 있으므로 직접 실행하지 않는 편이 안전합니다.',
+    englishLabel: 'UNKNOWN ACTION',
+    previewLabel: '알 수 없음',
+    title: '알 수 없는 실행 요청 감지',
+  },
+  wifi: {
+    buildDescription: (targetValue) =>
+      targetValue
+        ? `"${targetValue}" Wi-Fi 네트워크에 연결하려는 QR 코드입니다. 저장된 네트워크 정보가 있으면 자동 연결 설정으로 이어질 수 있습니다.`
+        : 'Wi-Fi 네트워크에 연결하려는 QR 코드입니다. SSID와 인증 방식이 포함되어 사용자를 특정 무선 네트워크로 유도합니다.',
+    caution:
+      '낯선 Wi-Fi 연결은 트래픽 가로채기, 피싱 포털, 악성 설정 유도로 이어질 수 있습니다. 네트워크 이름과 제공 주체를 먼저 확인해야 합니다.',
+    englishLabel: 'WIFI CONFIGURATION',
+    previewLabel: 'Wi-Fi',
+    sampleTargetValue: 'Veri-Q Guest',
+    title: 'Wi-Fi 연결 감지',
+  },
+};
+
+export const nonUrlActionPreviewItems: NonUrlActionPreviewItem[] = Object.entries(
+  nonUrlActionCatalog,
+).map(([actionType, catalogItem]) => ({
+  actionType: actionType as NonUrlActionType,
+  label: catalogItem.previewLabel,
+  sampleTargetValue: catalogItem.sampleTargetValue,
+}));
+
+export function resolveNonUrlActionContent(
+  actionType: NonUrlActionType,
+  targetValue?: string,
+): ResolvedNonUrlActionContent {
+  const catalogItem = nonUrlActionCatalog[actionType];
+
+  return {
+    caution: catalogItem.caution,
+    description: catalogItem.buildDescription(targetValue),
+    englishLabel: catalogItem.englishLabel,
+    title: catalogItem.title,
+  };
+}

--- a/src/pages/ResultNonUrl/hooks/useResultNonUrlPage.ts
+++ b/src/pages/ResultNonUrl/hooks/useResultNonUrlPage.ts
@@ -1,0 +1,59 @@
+import { useNavigate } from '@tanstack/react-router';
+import { useCallback, useEffect, useState } from 'react';
+
+import { shareCurrentPage } from '@/shared/lib/browser/shareCurrentPage';
+
+import {
+  fetchResultNonUrlPageData,
+  getInitialResultNonUrlPageData,
+} from '../api/fetchResultNonUrlPageData';
+
+import type { ResultNonUrlPageData } from '../types/resultNonUrlPage.types';
+
+type UseResultNonUrlPageReturn = {
+  handleRescan: () => void;
+  handleShareResult: () => Promise<void>;
+  resultNonUrlPageData: ResultNonUrlPageData;
+};
+
+export function useResultNonUrlPage(): UseResultNonUrlPageReturn {
+  const navigate = useNavigate();
+  const [resultNonUrlPageData, setResultNonUrlPageData] = useState<ResultNonUrlPageData>(
+    getInitialResultNonUrlPageData,
+  );
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadResultNonUrlPageData = async () => {
+      const response = await fetchResultNonUrlPageData();
+
+      if (isMounted) {
+        setResultNonUrlPageData(response);
+      }
+    };
+
+    void loadResultNonUrlPageData();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const handleRescan = useCallback(() => {
+    void navigate({ to: '/' });
+  }, [navigate]);
+
+  const handleShareResult = useCallback(async () => {
+    await shareCurrentPage({
+      text: 'Veri-Q 비 URL 분석 결과를 확인해 보세요.',
+      title: 'Veri-Q 비 URL 분석 결과',
+    });
+  }, []);
+
+  return {
+    handleRescan,
+    handleShareResult,
+    resultNonUrlPageData,
+  };
+}

--- a/src/pages/ResultNonUrl/hooks/useResultNonUrlPage.ts
+++ b/src/pages/ResultNonUrl/hooks/useResultNonUrlPage.ts
@@ -26,10 +26,14 @@ export function useResultNonUrlPage(): UseResultNonUrlPageReturn {
     let isMounted = true;
 
     const loadResultNonUrlPageData = async () => {
-      const response = await fetchResultNonUrlPageData();
+      try {
+        const response = await fetchResultNonUrlPageData();
 
-      if (isMounted) {
-        setResultNonUrlPageData(response);
+        if (isMounted) {
+          setResultNonUrlPageData(response);
+        }
+      } catch (error) {
+        console.error('[ResultNonUrlPage] failed to load page data', error);
       }
     };
 

--- a/src/pages/ResultNonUrl/index.ts
+++ b/src/pages/ResultNonUrl/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ResultNonUrlPage';

--- a/src/pages/ResultNonUrl/lib/resolveNonUrlActionExecution.ts
+++ b/src/pages/ResultNonUrl/lib/resolveNonUrlActionExecution.ts
@@ -21,7 +21,11 @@ function normalizePhoneNumber(targetValue?: string): string {
     return '';
   }
 
-  return targetValue.replace(/[^0-9+]/g, '');
+  return targetValue.trim().replace(/[\s()-]/g, '');
+}
+
+function isValidPhoneNumber(targetValue: string): boolean {
+  return /^\+?\d{7,15}$/u.test(targetValue);
 }
 
 export function resolveNonUrlActionExecution(
@@ -32,7 +36,7 @@ export function resolveNonUrlActionExecution(
     case 'telSms': {
       const normalizedPhoneNumber = normalizePhoneNumber(targetValue);
 
-      if (!normalizedPhoneNumber) {
+      if (!isValidPhoneNumber(normalizedPhoneNumber)) {
         return {
           kind: 'unsupported',
           message: '전화 또는 문자 실행을 위한 번호 정보가 없습니다.',

--- a/src/pages/ResultNonUrl/lib/resolveNonUrlActionExecution.ts
+++ b/src/pages/ResultNonUrl/lib/resolveNonUrlActionExecution.ts
@@ -1,0 +1,95 @@
+import type { NonUrlActionType } from '../types/resultNonUrlPage.types';
+
+export type NonUrlActionExecutionPlan =
+  | {
+      href: string;
+      kind: 'navigate';
+      message: string;
+    }
+  | {
+      kind: 'open';
+      message: string;
+      url: string;
+    }
+  | {
+      kind: 'unsupported';
+      message: string;
+    };
+
+function normalizePhoneNumber(targetValue?: string): string {
+  if (!targetValue) {
+    return '';
+  }
+
+  return targetValue.replace(/[^0-9+]/g, '');
+}
+
+export function resolveNonUrlActionExecution(
+  actionType: NonUrlActionType,
+  targetValue?: string,
+): NonUrlActionExecutionPlan {
+  switch (actionType) {
+    case 'telSms': {
+      const normalizedPhoneNumber = normalizePhoneNumber(targetValue);
+
+      if (!normalizedPhoneNumber) {
+        return {
+          kind: 'unsupported',
+          message: '전화 또는 문자 실행을 위한 번호 정보가 없습니다.',
+        };
+      }
+
+      return {
+        href: `tel:${normalizedPhoneNumber}`,
+        kind: 'navigate',
+        message: '전화 앱 실행을 시도합니다.',
+      };
+    }
+
+    case 'appStore': {
+      const keyword = (targetValue ?? '').trim();
+
+      return {
+        kind: 'open',
+        message: '앱 스토어 검색 페이지를 엽니다.',
+        url: `https://play.google.com/store/search?c=apps&q=${encodeURIComponent(keyword || 'app')}`,
+      };
+    }
+
+    case 'bitcoin': {
+      const walletAddress = (targetValue ?? '').trim();
+
+      if (!walletAddress) {
+        return {
+          kind: 'unsupported',
+          message: '비트코인 지갑 주소 정보가 없습니다.',
+        };
+      }
+
+      return {
+        href: `bitcoin:${walletAddress}`,
+        kind: 'navigate',
+        message: '비트코인 지갑 실행을 시도합니다.',
+      };
+    }
+
+    case 'wifi':
+      return {
+        kind: 'unsupported',
+        message: '브라우저에서는 Wi-Fi 연결 QR을 직접 실행할 수 없습니다.',
+      };
+
+    case 'appLaunch':
+      return {
+        kind: 'unsupported',
+        message: '앱 실행을 위한 정확한 스킴 정보가 없어 브라우저에서 바로 실행할 수 없습니다.',
+      };
+
+    case 'unknown':
+    default:
+      return {
+        kind: 'unsupported',
+        message: '정확한 실행 방식을 알 수 없어 안전상 직접 실행을 막았습니다.',
+      };
+  }
+}

--- a/src/pages/ResultNonUrl/styles/resultNonUrlPage.css.ts
+++ b/src/pages/ResultNonUrl/styles/resultNonUrlPage.css.ts
@@ -2,6 +2,33 @@ import { style } from '@vanilla-extract/css';
 
 import { vars } from '@/vars.css';
 
+const nonUrlPalette = {
+  accentEnd: '#D9B800',
+  accentStart: vars.colors.warning,
+  actionBodyBackground: '#FFF9E8',
+  actionBodyBorder: 'rgba(242, 223, 13, 0.4)',
+  actionCardBorder: 'rgba(242, 223, 13, 0.34)',
+  actionCardShadow: '0 20px 48px rgba(242, 223, 13, 0.08)',
+  actionDivider: 'rgba(217, 184, 0, 0.32)',
+  actionTitleText: '#16345B',
+  cautionText: '#50637C',
+  detailText: '#B28300',
+  executionButtonShadow: '0 14px 32px rgba(242, 223, 13, 0.18)',
+  focusRing: 'rgba(0, 106, 228, 0.24)',
+  previewActiveText: '#3D3200',
+  previewBackground: '#FFFBEF',
+  previewBorder: 'rgba(242, 223, 13, 0.28)',
+  previewText: '#7D6200',
+  previewValueText: '#6F5A00',
+  sectionBackground: '#FFFDF6',
+  sectionBorder: 'rgba(242, 223, 13, 0.45)',
+  sectionNumberBackground: '#FFF1B8',
+  sectionNumberBorder: 'rgba(242, 223, 13, 0.72)',
+  sectionNumberText: '#A27200',
+  strongText: '#1D3557',
+  subtleText: '#7D8FB3',
+};
+
 export const futureContent = style({
   display: 'grid',
   gap: vars.spacing.md,
@@ -12,8 +39,8 @@ export const analysisSection = style({
   gap: vars.spacing.md,
   padding: vars.spacing.lg,
   borderRadius: '24px',
-  border: '1px solid rgba(242, 223, 13, 0.45)',
-  backgroundColor: '#FFFDF6',
+  border: `1px solid ${nonUrlPalette.sectionBorder}`,
+  backgroundColor: nonUrlPalette.sectionBackground,
 });
 
 export const sectionHeader = style({
@@ -30,9 +57,9 @@ export const sectionNumber = style({
   height: '32px',
   padding: '0 10px',
   borderRadius: '12px',
-  backgroundColor: '#FFF1B8',
-  border: '1px solid rgba(242, 223, 13, 0.72)',
-  color: '#A27200',
+  backgroundColor: nonUrlPalette.sectionNumberBackground,
+  border: `1px solid ${nonUrlPalette.sectionNumberBorder}`,
+  color: nonUrlPalette.sectionNumberText,
   fontSize: vars.font.size.sm,
   fontWeight: vars.font.weight.bold,
   lineHeight: 1,
@@ -45,7 +72,7 @@ export const sectionHeaderTextBlock = style({
 
 export const sectionTitle = style({
   margin: 0,
-  color: '#1D3557',
+  color: nonUrlPalette.strongText,
   fontSize: 'clamp(20px, 2.6vw, 28px)',
   fontWeight: vars.font.weight.bold,
   lineHeight: 1.3,
@@ -63,9 +90,9 @@ export const actionCard = style({
   gap: vars.spacing.md,
   padding: vars.spacing.lg,
   borderRadius: '24px',
-  border: '1px solid rgba(242, 223, 13, 0.34)',
+  border: `1px solid ${nonUrlPalette.actionCardBorder}`,
   backgroundColor: vars.colors.white,
-  boxShadow: '0 20px 48px rgba(242, 223, 13, 0.08)',
+  boxShadow: nonUrlPalette.actionCardShadow,
 });
 
 export const actionCardHeader = style({
@@ -79,7 +106,7 @@ export const actionAccent = style({
   width: '4px',
   minHeight: '52px',
   borderRadius: '999px',
-  background: 'linear-gradient(180deg, #F2DF0D 0%, #D9B800 100%)',
+  background: `linear-gradient(180deg, ${nonUrlPalette.accentStart} 0%, ${nonUrlPalette.accentEnd} 100%)`,
 });
 
 export const actionHeaderTextBlock = style({
@@ -89,7 +116,7 @@ export const actionHeaderTextBlock = style({
 
 export const actionTitle = style({
   margin: 0,
-  color: '#16345B',
+  color: nonUrlPalette.actionTitleText,
   fontSize: 'clamp(20px, 2.8vw, 34px)',
   fontWeight: vars.font.weight.bold,
   lineHeight: 1.25,
@@ -98,7 +125,7 @@ export const actionTitle = style({
 
 export const actionEnglishLabel = style({
   margin: 0,
-  color: '#7D8FB3',
+  color: nonUrlPalette.subtleText,
   fontSize: 'clamp(13px, 1.3vw, 18px)',
   fontWeight: vars.font.weight.semibold,
   letterSpacing: '0.08em',
@@ -111,8 +138,8 @@ export const actionBody = style({
   gap: vars.spacing.md,
   padding: vars.spacing.lg,
   borderRadius: '20px',
-  backgroundColor: '#FFF9E8',
-  border: '1px solid rgba(242, 223, 13, 0.4)',
+  backgroundColor: nonUrlPalette.actionBodyBackground,
+  border: `1px solid ${nonUrlPalette.actionBodyBorder}`,
 });
 
 export const detailLabelRow = style({
@@ -125,12 +152,12 @@ export const detailLabelDot = style({
   width: '10px',
   height: '10px',
   borderRadius: '999px',
-  backgroundColor: '#D9B800',
+  backgroundColor: nonUrlPalette.accentEnd,
 });
 
 export const detailLabel = style({
   margin: 0,
-  color: '#B28300',
+  color: nonUrlPalette.detailText,
   fontSize: vars.font.size.md,
   fontWeight: vars.font.weight.bold,
   lineHeight: 1.4,
@@ -138,7 +165,7 @@ export const detailLabel = style({
 
 export const actionDescription = style({
   margin: 0,
-  color: '#16345B',
+  color: nonUrlPalette.actionTitleText,
   fontSize: 'clamp(16px, 1.7vw, 22px)',
   fontWeight: vars.font.weight.medium,
   lineHeight: 1.7,
@@ -148,19 +175,19 @@ export const actionDescription = style({
 export const actionDivider = style({
   width: '100%',
   height: '1px',
-  backgroundColor: 'rgba(217, 184, 0, 0.32)',
+  backgroundColor: nonUrlPalette.actionDivider,
 });
 
 export const actionCaution = style({
   margin: 0,
-  color: '#50637C',
+  color: nonUrlPalette.cautionText,
   fontSize: 'clamp(15px, 1.5vw, 20px)',
   lineHeight: 1.75,
   wordBreak: 'keep-all',
 });
 
 export const actionCautionLabel = style({
-  color: '#B28300',
+  color: nonUrlPalette.detailText,
   fontWeight: vars.font.weight.bold,
 });
 
@@ -175,12 +202,25 @@ export const executionButton = style({
   fontWeight: vars.font.weight.bold,
   lineHeight: 1.2,
   cursor: 'pointer',
-  boxShadow: '0 14px 32px rgba(242, 223, 13, 0.18)',
+  boxShadow: nonUrlPalette.executionButtonShadow,
+  selectors: {
+    '&:focus-visible': {
+      outline: `2px solid ${vars.colors.main}`,
+      outlineOffset: '3px',
+      boxShadow: `0 0 0 4px ${nonUrlPalette.focusRing}, ${nonUrlPalette.executionButtonShadow}`,
+    },
+    '&:disabled': {
+      opacity: 0.55,
+      cursor: 'not-allowed',
+      pointerEvents: 'none',
+      boxShadow: 'none',
+    },
+  },
 });
 
 export const executionFeedback = style({
   margin: 0,
-  color: '#7D6200',
+  color: nonUrlPalette.previewText,
   fontSize: vars.font.size.sm,
   lineHeight: 1.6,
   textAlign: 'center',
@@ -191,13 +231,13 @@ export const previewSection = style({
   gap: vars.spacing.sm,
   padding: vars.spacing.md,
   borderRadius: vars.radius.lg,
-  border: '1px solid rgba(242, 223, 13, 0.28)',
-  backgroundColor: '#FFFBEF',
+  border: `1px solid ${nonUrlPalette.previewBorder}`,
+  backgroundColor: nonUrlPalette.previewBackground,
 });
 
 export const previewTitle = style({
   margin: 0,
-  color: '#7D6200',
+  color: nonUrlPalette.previewText,
   fontSize: vars.font.size.md,
   fontWeight: vars.font.weight.semibold,
   lineHeight: 1.5,
@@ -210,19 +250,45 @@ export const previewButtonList = style({
 });
 
 export const previewButton = style({
-  border: '1px solid rgba(242, 223, 13, 0.45)',
+  border: `1px solid ${nonUrlPalette.sectionBorder}`,
   borderRadius: '999px',
   backgroundColor: vars.colors.white,
-  color: '#6F5A00',
+  color: nonUrlPalette.previewValueText,
   padding: '8px 14px',
   fontSize: vars.font.size.sm,
   fontWeight: vars.font.weight.medium,
   lineHeight: 1.2,
   cursor: 'pointer',
+  selectors: {
+    '&:focus-visible': {
+      outline: `2px solid ${vars.colors.main}`,
+      outlineOffset: '2px',
+      boxShadow: `0 0 0 4px ${nonUrlPalette.focusRing}`,
+    },
+    '&:disabled': {
+      opacity: 0.55,
+      cursor: 'not-allowed',
+      pointerEvents: 'none',
+      boxShadow: 'none',
+    },
+  },
 });
 
 export const previewButtonActive = style({
-  backgroundColor: '#F2DF0D',
-  borderColor: '#D9B800',
-  color: '#3D3200',
+  backgroundColor: vars.colors.warning,
+  borderColor: nonUrlPalette.accentEnd,
+  color: nonUrlPalette.previewActiveText,
+  selectors: {
+    '&:focus-visible': {
+      outline: `2px solid ${vars.colors.main}`,
+      outlineOffset: '2px',
+      boxShadow: `0 0 0 4px ${nonUrlPalette.focusRing}`,
+    },
+    '&:disabled': {
+      opacity: 0.55,
+      cursor: 'not-allowed',
+      pointerEvents: 'none',
+      boxShadow: 'none',
+    },
+  },
 });

--- a/src/pages/ResultNonUrl/styles/resultNonUrlPage.css.ts
+++ b/src/pages/ResultNonUrl/styles/resultNonUrlPage.css.ts
@@ -1,0 +1,228 @@
+import { style } from '@vanilla-extract/css';
+
+import { vars } from '@/vars.css';
+
+export const futureContent = style({
+  display: 'grid',
+  gap: vars.spacing.md,
+});
+
+export const analysisSection = style({
+  display: 'grid',
+  gap: vars.spacing.md,
+  padding: vars.spacing.lg,
+  borderRadius: '24px',
+  border: '1px solid rgba(242, 223, 13, 0.45)',
+  backgroundColor: '#FFFDF6',
+});
+
+export const sectionHeader = style({
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: vars.spacing.md,
+});
+
+export const sectionNumber = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  minWidth: '32px',
+  height: '32px',
+  padding: '0 10px',
+  borderRadius: '12px',
+  backgroundColor: '#FFF1B8',
+  border: '1px solid rgba(242, 223, 13, 0.72)',
+  color: '#A27200',
+  fontSize: vars.font.size.sm,
+  fontWeight: vars.font.weight.bold,
+  lineHeight: 1,
+});
+
+export const sectionHeaderTextBlock = style({
+  display: 'grid',
+  gap: vars.spacing.xs,
+});
+
+export const sectionTitle = style({
+  margin: 0,
+  color: '#1D3557',
+  fontSize: 'clamp(20px, 2.6vw, 28px)',
+  fontWeight: vars.font.weight.bold,
+  lineHeight: 1.3,
+});
+
+export const sectionDescription = style({
+  margin: 0,
+  color: vars.colors.subText,
+  fontSize: vars.font.size.sm,
+  lineHeight: 1.6,
+});
+
+export const actionCard = style({
+  display: 'grid',
+  gap: vars.spacing.md,
+  padding: vars.spacing.lg,
+  borderRadius: '24px',
+  border: '1px solid rgba(242, 223, 13, 0.34)',
+  backgroundColor: vars.colors.white,
+  boxShadow: '0 20px 48px rgba(242, 223, 13, 0.08)',
+});
+
+export const actionCardHeader = style({
+  display: 'flex',
+  alignItems: 'flex-start',
+  gap: vars.spacing.md,
+});
+
+export const actionAccent = style({
+  flexShrink: 0,
+  width: '4px',
+  minHeight: '52px',
+  borderRadius: '999px',
+  background: 'linear-gradient(180deg, #F2DF0D 0%, #D9B800 100%)',
+});
+
+export const actionHeaderTextBlock = style({
+  display: 'grid',
+  gap: vars.spacing.xs,
+});
+
+export const actionTitle = style({
+  margin: 0,
+  color: '#16345B',
+  fontSize: 'clamp(20px, 2.8vw, 34px)',
+  fontWeight: vars.font.weight.bold,
+  lineHeight: 1.25,
+  wordBreak: 'keep-all',
+});
+
+export const actionEnglishLabel = style({
+  margin: 0,
+  color: '#7D8FB3',
+  fontSize: 'clamp(13px, 1.3vw, 18px)',
+  fontWeight: vars.font.weight.semibold,
+  letterSpacing: '0.08em',
+  lineHeight: 1.4,
+  textTransform: 'uppercase',
+});
+
+export const actionBody = style({
+  display: 'grid',
+  gap: vars.spacing.md,
+  padding: vars.spacing.lg,
+  borderRadius: '20px',
+  backgroundColor: '#FFF9E8',
+  border: '1px solid rgba(242, 223, 13, 0.4)',
+});
+
+export const detailLabelRow = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: vars.spacing.sm,
+});
+
+export const detailLabelDot = style({
+  width: '10px',
+  height: '10px',
+  borderRadius: '999px',
+  backgroundColor: '#D9B800',
+});
+
+export const detailLabel = style({
+  margin: 0,
+  color: '#B28300',
+  fontSize: vars.font.size.md,
+  fontWeight: vars.font.weight.bold,
+  lineHeight: 1.4,
+});
+
+export const actionDescription = style({
+  margin: 0,
+  color: '#16345B',
+  fontSize: 'clamp(16px, 1.7vw, 22px)',
+  fontWeight: vars.font.weight.medium,
+  lineHeight: 1.7,
+  wordBreak: 'keep-all',
+});
+
+export const actionDivider = style({
+  width: '100%',
+  height: '1px',
+  backgroundColor: 'rgba(217, 184, 0, 0.32)',
+});
+
+export const actionCaution = style({
+  margin: 0,
+  color: '#50637C',
+  fontSize: 'clamp(15px, 1.5vw, 20px)',
+  lineHeight: 1.75,
+  wordBreak: 'keep-all',
+});
+
+export const actionCautionLabel = style({
+  color: '#B28300',
+  fontWeight: vars.font.weight.bold,
+});
+
+export const executionButton = style({
+  width: '100%',
+  border: 0,
+  borderRadius: vars.radius.lg,
+  backgroundColor: vars.colors.warning,
+  color: vars.colors.black,
+  padding: '14px 18px',
+  fontSize: vars.font.size.md,
+  fontWeight: vars.font.weight.bold,
+  lineHeight: 1.2,
+  cursor: 'pointer',
+  boxShadow: '0 14px 32px rgba(242, 223, 13, 0.18)',
+});
+
+export const executionFeedback = style({
+  margin: 0,
+  color: '#7D6200',
+  fontSize: vars.font.size.sm,
+  lineHeight: 1.6,
+  textAlign: 'center',
+});
+
+export const previewSection = style({
+  display: 'grid',
+  gap: vars.spacing.sm,
+  padding: vars.spacing.md,
+  borderRadius: vars.radius.lg,
+  border: '1px solid rgba(242, 223, 13, 0.28)',
+  backgroundColor: '#FFFBEF',
+});
+
+export const previewTitle = style({
+  margin: 0,
+  color: '#7D6200',
+  fontSize: vars.font.size.md,
+  fontWeight: vars.font.weight.semibold,
+  lineHeight: 1.5,
+});
+
+export const previewButtonList = style({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: vars.spacing.sm,
+});
+
+export const previewButton = style({
+  border: '1px solid rgba(242, 223, 13, 0.45)',
+  borderRadius: '999px',
+  backgroundColor: vars.colors.white,
+  color: '#6F5A00',
+  padding: '8px 14px',
+  fontSize: vars.font.size.sm,
+  fontWeight: vars.font.weight.medium,
+  lineHeight: 1.2,
+  cursor: 'pointer',
+});
+
+export const previewButtonActive = style({
+  backgroundColor: '#F2DF0D',
+  borderColor: '#D9B800',
+  color: '#3D3200',
+});

--- a/src/pages/ResultNonUrl/types/resultNonUrlPage.types.ts
+++ b/src/pages/ResultNonUrl/types/resultNonUrlPage.types.ts
@@ -1,0 +1,9 @@
+export type NonUrlActionType = 'appLaunch' | 'appStore' | 'bitcoin' | 'telSms' | 'unknown' | 'wifi';
+
+export type ResultNonUrlPageData = {
+  detectedActionType: NonUrlActionType;
+  sectionDescription: string;
+  sectionNumber: string;
+  sectionTitle: string;
+  targetValue?: string;
+};

--- a/src/pages/ResultNonUrl/ui/DetectedNonUrlActionSection.tsx
+++ b/src/pages/ResultNonUrl/ui/DetectedNonUrlActionSection.tsx
@@ -1,0 +1,61 @@
+import { resolveNonUrlActionContent } from '../constants/nonUrlActionCatalog';
+import * as styles from '../styles/resultNonUrlPage.css';
+
+import type { NonUrlActionType } from '../types/resultNonUrlPage.types';
+
+type DetectedNonUrlActionSectionProps = {
+  actionType: NonUrlActionType;
+  sectionDescription: string;
+  sectionNumber: string;
+  sectionTitle: string;
+  targetValue?: string;
+};
+
+export default function DetectedNonUrlActionSection({
+  actionType,
+  sectionDescription,
+  sectionNumber,
+  sectionTitle,
+  targetValue,
+}: DetectedNonUrlActionSectionProps) {
+  const resolvedContent = resolveNonUrlActionContent(actionType, targetValue);
+
+  return (
+    <section className={styles.analysisSection}>
+      <div className={styles.sectionHeader}>
+        <span className={styles.sectionNumber}>{sectionNumber}</span>
+
+        <div className={styles.sectionHeaderTextBlock}>
+          <h2 className={styles.sectionTitle}>{sectionTitle}</h2>
+          <p className={styles.sectionDescription}>{sectionDescription}</p>
+        </div>
+      </div>
+
+      <article className={styles.actionCard}>
+        <div className={styles.actionCardHeader}>
+          <div className={styles.actionAccent} />
+
+          <div className={styles.actionHeaderTextBlock}>
+            <h3 className={styles.actionTitle}>{resolvedContent.title}</h3>
+            <p className={styles.actionEnglishLabel}>{resolvedContent.englishLabel}</p>
+          </div>
+        </div>
+
+        <div className={styles.actionBody}>
+          <div className={styles.detailLabelRow}>
+            <span aria-hidden className={styles.detailLabelDot} />
+            <p className={styles.detailLabel}>상세 설명</p>
+          </div>
+
+          <p className={styles.actionDescription}>{resolvedContent.description}</p>
+
+          <div className={styles.actionDivider} />
+
+          <p className={styles.actionCaution}>
+            <span className={styles.actionCautionLabel}>주의:</span> {resolvedContent.caution}
+          </p>
+        </div>
+      </article>
+    </section>
+  );
+}

--- a/src/pages/ResultSafe/ui/ResultSafeHero.tsx
+++ b/src/pages/ResultSafe/ui/ResultSafeHero.tsx
@@ -1,23 +1,17 @@
-import { statusMarkIconByTone } from '@/shared/icon/resultIcons';
-
-import * as styles from '../styles/resultSafePage.css';
+import ResultHero from '@/shared/ui/resultHero';
 
 export default function ResultSafeHero() {
   return (
-    <header className={styles.hero}>
-      <div className={styles.statusHalo}>
-        <img alt="" aria-hidden className={styles.statusBadge} src={statusMarkIconByTone.safe} />
-      </div>
-
-      <h1 className={styles.heroTitle}>
-        안심하세요!
-        <br />
-        안전한 사이트입니다
-      </h1>
-
-      <p className={styles.heroDescription}>
-        Veri-Q 분석 결과, 해당 QR 코드는 검증된 안전한 웹사이트로 연결됩니다.
-      </p>
-    </header>
+    <ResultHero
+      description="Veri-Q 분석 결과, 해당 QR 코드는 검증된 안전한 웹사이트로 연결됩니다."
+      title={
+        <>
+          안심하세요!
+          <br />
+          안전한 사이트입니다
+        </>
+      }
+      tone="safe"
+    />
   );
 }

--- a/src/pages/ResultWarning/ui/ResultWarningHero.tsx
+++ b/src/pages/ResultWarning/ui/ResultWarningHero.tsx
@@ -1,23 +1,17 @@
-import { statusMarkIconByTone } from '@/shared/icon/resultIcons';
-
-import * as styles from '../styles/resultWarningPage.css';
+import ResultHero from '@/shared/ui/resultHero';
 
 export default function ResultWarningHero() {
   return (
-    <header className={styles.hero}>
-      <div className={styles.statusHalo}>
-        <img alt="" aria-hidden className={styles.statusBadge} src={statusMarkIconByTone.warning} />
-      </div>
-
-      <h1 className={styles.heroTitle}>
-        주의하세요!
-        <br />
-        주의가 필요한 사이트입니다
-      </h1>
-
-      <p className={styles.heroDescription}>
-        Veri-Q 분석 결과, 해당 QR 코드는 주의가 필요한 웹사이트로 분류되었습니다.
-      </p>
-    </header>
+    <ResultHero
+      description="Veri-Q 분석 결과, 해당 QR 코드는 주의가 필요한 웹사이트로 분류되었습니다."
+      title={
+        <>
+          주의하세요!
+          <br />
+          주의가 필요한 사이트입니다
+        </>
+      }
+      tone="warning"
+    />
   );
 }

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -5,6 +5,7 @@ import HomePage from '@/pages/Home';
 import LoadingPage from '@/pages/Loading';
 import ReportPage from '@/pages/Report';
 import ResultCriticalPage from '@/pages/ResultCritical';
+import ResultNonUrlPage from '@/pages/ResultNonUrl';
 import ResultSafePage from '@/pages/ResultSafe';
 import ResultWarningPage from '@/pages/ResultWarning';
 import ScanHistoryPage from '@/pages/ScanHistory';
@@ -53,6 +54,12 @@ const resultCriticalRoute = createRoute({
   component: ResultCriticalPage,
 });
 
+const resultNonUrlRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/result/non-url',
+  component: ResultNonUrlPage,
+});
+
 const resultSafeRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/result/safe',
@@ -72,6 +79,7 @@ const routeTree = rootRoute.addChildren([
   reportRoute,
   scanHistoryRoute,
   resultCriticalRoute,
+  resultNonUrlRoute,
   resultSafeRoute,
   resultWarningRoute,
 ]);

--- a/src/shared/ui/resultHero/ResultHero.tsx
+++ b/src/shared/ui/resultHero/ResultHero.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react';
+
+import { statusMarkIconByTone } from '@/shared/icon/resultIcons';
+import type { ResultTone } from '@/shared/types/resultTone';
+
+import * as styles from './resultHero.css';
+
+type ResultHeroProps = {
+  description: ReactNode;
+  title: ReactNode;
+  tone: ResultTone;
+};
+
+export default function ResultHero({ description, title, tone }: ResultHeroProps) {
+  return (
+    <header className={styles.root}>
+      <div className={styles.statusHalo}>
+        <img alt="" aria-hidden className={styles.statusBadge} src={statusMarkIconByTone[tone]} />
+      </div>
+
+      <h1 className={styles.titleTone[tone]}>{title}</h1>
+      <p className={styles.descriptionTone[tone]}>{description}</p>
+    </header>
+  );
+}

--- a/src/shared/ui/resultHero/index.ts
+++ b/src/shared/ui/resultHero/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ResultHero';

--- a/src/shared/ui/resultHero/resultHero.css.ts
+++ b/src/shared/ui/resultHero/resultHero.css.ts
@@ -69,7 +69,7 @@ export const descriptionTone = styleVariants<Record<ResultTone, object>>({
   critical: [
     baseDescription,
     {
-      color: '#D98282',
+      color: vars.colors.resultCriticalText,
     },
   ],
   safe: [
@@ -81,7 +81,7 @@ export const descriptionTone = styleVariants<Record<ResultTone, object>>({
   warning: [
     baseDescription,
     {
-      color: '#C8B95A',
+      color: vars.colors.resultWarningText,
     },
   ],
 });

--- a/src/shared/ui/resultHero/resultHero.css.ts
+++ b/src/shared/ui/resultHero/resultHero.css.ts
@@ -1,0 +1,87 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+
+import type { ResultTone } from '@/shared/types/resultTone';
+
+import { vars } from '@/vars.css';
+
+export const root = style({
+  display: 'grid',
+  justifyItems: 'center',
+  textAlign: 'center',
+  gap: vars.spacing.md,
+});
+
+export const statusHalo = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 'clamp(216px, 40vw, 270px)',
+  height: 'clamp(216px, 40vw, 270px)',
+});
+
+export const statusBadge = style({
+  display: 'block',
+  width: '100%',
+  height: '100%',
+  objectFit: 'contain',
+});
+
+const baseTitle = style({
+  margin: 0,
+  fontWeight: vars.font.weight.bold,
+  letterSpacing: '-0.02em',
+});
+
+export const titleTone = styleVariants<Record<ResultTone, object>>({
+  critical: [
+    baseTitle,
+    {
+      color: vars.colors.error,
+      fontSize: 'clamp(30px, 4.4vw, 44px)',
+      lineHeight: 1.25,
+    },
+  ],
+  safe: [
+    baseTitle,
+    {
+      color: vars.colors.black,
+      fontSize: 'clamp(32px, 5vw, 48px)',
+      lineHeight: 1.15,
+    },
+  ],
+  warning: [
+    baseTitle,
+    {
+      color: vars.colors.black,
+      fontSize: 'clamp(32px, 5vw, 48px)',
+      lineHeight: 1.15,
+    },
+  ],
+});
+
+const baseDescription = style({
+  margin: 0,
+  fontSize: vars.font.size.md,
+  lineHeight: 1.6,
+});
+
+export const descriptionTone = styleVariants<Record<ResultTone, object>>({
+  critical: [
+    baseDescription,
+    {
+      color: '#D98282',
+    },
+  ],
+  safe: [
+    baseDescription,
+    {
+      color: vars.colors.subText,
+    },
+  ],
+  warning: [
+    baseDescription,
+    {
+      color: '#C8B95A',
+    },
+  ],
+});

--- a/src/vars.css.ts
+++ b/src/vars.css.ts
@@ -19,6 +19,8 @@ export const vars = createGlobalTheme('#app', {
     error: '#F20D0D',
     success: '#11D483',
     warning: '#F2DF0D',
+    resultCriticalText: '#D98282',
+    resultWarningText: '#C8B95A',
   },
   font: {
     size: {


### PR DESCRIPTION
## Summary
#14 
  * QR 코드에서 감지된 비URL 작업(앱 실행, 비트코인, 전화/SMS, WiFi, 앱스토어 등)을 처리하는 새로운 결과 페이지 추가
  * 감지된 작업 유형에 따른 동적 콘텐츠 표시 및 실행 기능 구현

## Tasks

- warning/safe/critical 상단 Hero 공통화
- 비URL 유형 데이터, 카드, 실행 로직 추가
- 실제 페이지 렌더링과 라우트 연결
## Screenshot

<img width="716" height="1071" alt="image" src="https://github.com/user-attachments/assets/472e87d0-8689-477c-980f-59b33ebdfc49" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 비-URL QR 결과를 위한 새 결과 페이지(비URL 시나리오 선택, 실행 버튼, 피드백, 재스캔/공유) 추가
  * 비-URL 작업 목록/미리보기와 실행 플랜 해석(내비게이션/외부열기/지원불가) 도입
  * 페이지 데이터 피치(모의 데이터)와 전용 훅으로 데이터 로드·공유·재스캔 지원

* **Refactor**
  * 여러 결과 페이지의 헤더를 공통 ResultHero 컴포넌트로 통합하여 UI 일관성 향상

* **Style**
  * 비-URL 페이지 전용 스타일 토큰 및 레이아웃 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->