### PR TITLE
[KD-59] 스캔 이력 목록창 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,17 @@
   "private": true,
   "version": "0.1.0",
   "packageManager": "pnpm@10.13.1",
+  "pnpm": {
+    "overrides": {
+      "brace-expansion@^1.1.7": "^1.1.13",
+      "brace-expansion@^5.0.2": "^5.0.5",
+      "flatted": "^3.4.2",
+      "lodash": "^4.18.1",
+      "picomatch@^2.3.1": "^2.3.2",
+      "picomatch@^4.0.3": "^4.0.4",
+      "yaml": "^2.8.3"
+    }
+  },
   "scripts": {
     "postinstall": "node scripts/setupEnv.mjs",
     "dev:captcha-server": "node scripts/captchaVerifyServer.mjs",
@@ -54,7 +65,7 @@
     "@vanilla-extract/css": "^1.18.0",
     "antd": "^6.3.2",
     "html2canvas": "^1.4.1",
-    "jspdf": "^4.2.0",
+    "jspdf": "^4.2.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,15 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion@^1.1.7: ^1.1.13
+  brace-expansion@^5.0.2: ^5.0.5
+  flatted: ^3.4.2
+  lodash: ^4.18.1
+  picomatch@^2.3.1: ^2.3.2
+  picomatch@^4.0.3: ^4.0.4
+  yaml: ^2.8.3
+
 importers:
   .:
     dependencies:
@@ -20,8 +29,8 @@ importers:
         specifier: ^1.4.1
         version: 1.4.1
       jspdf:
-        specifier: ^4.2.0
-        version: 4.2.0
+        specifier: ^4.2.1
+        version: 4.2.1
       react:
         specifier: ^19.1.1
         version: 19.2.4
@@ -46,10 +55,10 @@ importers:
         version: 8.56.1(eslint@9.39.4)(typescript@5.9.3)
       '@vanilla-extract/vite-plugin':
         specifier: ^5.1.0
-        version: 5.1.4(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(vite@7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
+        version: 5.1.4(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(vite@7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       '@vitejs/plugin-react':
         specifier: ^5.1.0
-        version: 5.1.4(vite@7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 5.1.4(vite@7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       eslint:
         specifier: ^9.39.1
         version: 9.39.4
@@ -76,10 +85,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.4(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
 
 packages:
   '@ant-design/colors@8.0.1':
@@ -1919,16 +1928,16 @@ packages:
         integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==,
       }
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.13:
     resolution:
       {
-        integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==,
+        integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==,
       }
 
-  brace-expansion@5.0.4:
+  brace-expansion@5.0.5:
     resolution:
       {
-        integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==,
+        integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==,
       }
     engines: { node: 18 || 20 || >=22 }
 
@@ -2586,7 +2595,7 @@ packages:
       }
     engines: { node: '>=12.0.0' }
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: ^4.0.4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -2625,10 +2634,10 @@ packages:
       }
     engines: { node: '>=16' }
 
-  flatted@3.4.1:
+  flatted@3.4.2:
     resolution:
       {
-        integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==,
+        integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==,
       }
 
   for-each@0.3.5:
@@ -3164,10 +3173,10 @@ packages:
     engines: { node: '>=6' }
     hasBin: true
 
-  jspdf@4.2.0:
+  jspdf@4.2.1:
     resolution:
       {
-        integrity: sha512-hR/hnRevAXXlrjeqU5oahOE+Ln9ORJUB5brLHHqH67A+RBQZuFr5GkbI9XQI8OUFSEezKegsi45QRpc4bGj75Q==,
+        integrity: sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==,
       }
 
   keyv@4.5.4:
@@ -3304,10 +3313,10 @@ packages:
         integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==,
       }
 
-  lodash@4.17.23:
+  lodash@4.18.1:
     resolution:
       {
-        integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==,
+        integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==,
       }
 
   log-update@6.1.0:
@@ -3595,17 +3604,17 @@ packages:
         integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
       }
 
-  picomatch@2.3.1:
+  picomatch@2.3.2:
     resolution:
       {
-        integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==,
+        integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==,
       }
     engines: { node: '>=8.6' }
 
-  picomatch@4.0.3:
+  picomatch@4.0.4:
     resolution:
       {
-        integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==,
+        integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
       }
     engines: { node: '>=12' }
 
@@ -4475,7 +4484,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: ^2.8.3
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -4595,10 +4604,10 @@ packages:
         integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==,
       }
 
-  yaml@2.8.2:
+  yaml@2.8.3:
     resolution:
       {
-        integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==,
+        integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==,
       }
     engines: { node: '>= 14.6' }
     hasBin: true
@@ -5497,7 +5506,7 @@ snapshots:
       chalk: 4.1.2
       debug: 4.4.3
       js-yaml: 4.1.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       pluralize: 2.0.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
@@ -5628,12 +5637,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vanilla-extract/compiler@0.3.4(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)':
+  '@vanilla-extract/compiler@0.3.4(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)':
     dependencies:
       '@vanilla-extract/css': 1.18.0
       '@vanilla-extract/integration': 8.0.7
-      vite: 7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      vite-node: 3.2.4(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -5684,11 +5693,11 @@ snapshots:
 
   '@vanilla-extract/private@1.0.9': {}
 
-  '@vanilla-extract/vite-plugin@5.1.4(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(vite@7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)':
+  '@vanilla-extract/vite-plugin@5.1.4(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(vite@7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)':
     dependencies:
-      '@vanilla-extract/compiler': 0.3.4(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      '@vanilla-extract/compiler': 0.3.4(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
       '@vanilla-extract/integration': 8.0.7
-      vite: 7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -5704,7 +5713,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@vitejs/plugin-react@5.1.4(vite@7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react@5.1.4(vite@7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -5712,7 +5721,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -5724,13 +5733,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -5925,12 +5934,12 @@ snapshots:
 
   boundary@2.0.0: {}
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.13:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.4:
+  brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6406,9 +6415,9 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   fflate@0.8.2: {}
 
@@ -6427,10 +6436,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.4.1
+      flatted: 3.4.2
       keyv: 4.5.4
 
-  flatted@3.4.1: {}
+  flatted@3.4.2: {}
 
   for-each@0.3.5:
     dependencies:
@@ -6723,7 +6732,7 @@ snapshots:
 
   json5@2.2.3: {}
 
-  jspdf@4.2.0:
+  jspdf@4.2.1:
     dependencies:
       '@babel/runtime': 7.28.6
       fast-png: 6.4.0
@@ -6793,7 +6802,7 @@ snapshots:
       micromatch: 4.0.8
       string-argv: 0.3.2
       tinyexec: 1.0.2
-      yaml: 2.8.2
+      yaml: 2.8.3
 
   listr2@9.0.5:
     dependencies:
@@ -6812,7 +6821,7 @@ snapshots:
 
   lodash.truncate@4.4.2: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   log-update@6.1.0:
     dependencies:
@@ -6845,17 +6854,17 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mimic-function@5.0.1: {}
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.4
+      brace-expansion: 5.0.5
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.13
 
   minimist@1.2.8: {}
 
@@ -6973,9 +6982,9 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -7409,8 +7418,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinypool@1.1.1: {}
 
@@ -7522,13 +7531,13 @@ snapshots:
 
   version-range@4.15.0: {}
 
-  vite-node@3.2.4(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vite-node@3.2.4(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -7543,11 +7552,11 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vite@7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
       postcss: 8.5.8
       rollup: 4.59.0
       tinyglobby: 0.2.15
@@ -7556,13 +7565,13 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.46.0
       tsx: 4.21.0
-      yaml: 2.8.2
+      yaml: 2.8.3
 
-  vitest@3.2.4(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@3.2.4(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -7573,15 +7582,15 @@ snapshots:
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
       tinyexec: 0.3.2
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      vite-node: 3.2.4(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@24.12.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.0
@@ -7659,6 +7668,6 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yaml@2.8.2: {}
+  yaml@2.8.3: {}
 
   yocto-queue@0.1.0: {}

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -8,6 +8,7 @@ const routeLinks = [
   { to: '/qr-scan', label: '/qr-scan' },
   { to: '/report', label: '/report' },
   { to: '/scan-history', label: '/scan-history' },
+  { to: '/scan-list', label: '/scan-list' },
   { to: '/result/critical', label: '/result/critical' },
   { to: '/result/non-url', label: '/result/non-url' },
   { to: '/result/safe', label: '/result/safe' },

--- a/src/pages/Home/HomePage.tsx
+++ b/src/pages/Home/HomePage.tsx
@@ -5,6 +5,7 @@ const routeLinks = [
   { to: '/', label: '/' },
   { to: '/captcha', label: '/captcha' },
   { to: '/loading', label: '/loading' },
+  { to: '/qr-scan', label: '/qr-scan' },
   { to: '/report', label: '/report' },
   { to: '/scan-history', label: '/scan-history' },
   { to: '/result/critical', label: '/result/critical' },

--- a/src/pages/QRScan/QRScanPage.tsx
+++ b/src/pages/QRScan/QRScanPage.tsx
@@ -1,0 +1,151 @@
+import { Link } from '@tanstack/react-router';
+
+import { qrIconByTone } from '@/shared/icon/resultIcons';
+import AppHeader from '@/shared/ui/app-header';
+
+import * as styles from './styles/qrScanPage.css';
+
+const recentScanRecord = {
+  scannedAt: '2023.10.27 14:32',
+  statusLabel: 'SAFE',
+  summary: '위험 요소가 발견되지 않았습니다.',
+  url: 'https://www.naver.com/',
+};
+
+function ScanGlyphIcon() {
+  return (
+    <svg aria-hidden="true" fill="none" viewBox="0 0 24 24">
+      <path
+        d="M8.5 4H6.75A2.75 2.75 0 0 0 4 6.75V8.5m11.5-4h1.75A2.75 2.75 0 0 1 20 6.75V8.5M8.5 20H6.75A2.75 2.75 0 0 1 4 17.25V15.5m11.5 4h1.75A2.75 2.75 0 0 0 20 17.25V15.5M9 9h2v2H9zm4 0h2v2h-2zM9 13h2v2H9zm4 0h2v2h-2z"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.8"
+      />
+    </svg>
+  );
+}
+
+function UploadGlyphIcon() {
+  return (
+    <svg aria-hidden="true" fill="none" viewBox="0 0 24 24">
+      <path
+        d="M12 15V6m0 0l-3 3m3-3l3 3M5 14.5v2.25A2.25 2.25 0 0 0 7.25 19h9.5A2.25 2.25 0 0 0 19 16.75V14.5"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.8"
+      />
+    </svg>
+  );
+}
+
+function ViewGlyphIcon() {
+  return (
+    <svg aria-hidden="true" fill="none" viewBox="0 0 24 24">
+      <path
+        d="M2.75 12s3.4-5.5 9.25-5.5 9.25 5.5 9.25 5.5-3.4 5.5-9.25 5.5S2.75 12 2.75 12Z"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.8"
+      />
+      <circle cx="12" cy="12" r="2.75" fill="currentColor" />
+    </svg>
+  );
+}
+
+export default function QRScanPage() {
+  return (
+    <main className={styles.page}>
+      <AppHeader iconSrc={qrIconByTone.safe} />
+
+      <div className={styles.shell}>
+        <section className={styles.heroSection}>
+          <div aria-hidden className={styles.scanStage}>
+            <div className={styles.scanBackdrop} />
+
+            <div className={styles.handSilhouette}>
+              <div className={styles.handPalm} />
+              <div className={styles.handThumb} />
+            </div>
+
+            <div className={styles.device}>
+              <div className={styles.deviceSpeaker} />
+
+              <div className={styles.deviceScreen}>
+                <div className={styles.deviceQrGhost} />
+                <div className={styles.deviceTextLine} />
+                <div className={styles.deviceTextLineShort} />
+              </div>
+
+              <div className={styles.deviceFooter}>
+                <span className={styles.deviceFooterDot} />
+                <span className={styles.deviceFooterDot} />
+                <span className={styles.deviceFooterDot} />
+              </div>
+            </div>
+
+            <div className={styles.scanLine} />
+
+            <div className={styles.centerBadge}>
+              <span className={styles.buttonIcon}>
+                <ScanGlyphIcon />
+              </span>
+            </div>
+
+            <span className={`${styles.scanCorner} ${styles.scanCornerTopLeft}`} />
+            <span className={`${styles.scanCorner} ${styles.scanCornerTopRight}`} />
+            <span className={`${styles.scanCorner} ${styles.scanCornerBottomLeft}`} />
+            <span className={`${styles.scanCorner} ${styles.scanCornerBottomRight}`} />
+          </div>
+
+          <header className={styles.intro}>
+            <h1 className={styles.title}>QR 스캔하기</h1>
+            <p className={styles.description}>안전한 스캔을 위해 QR을 프레임 안에 맞춰 주세요</p>
+          </header>
+        </section>
+
+        <section aria-label="QR 스캔 시작" className={styles.actionSection}>
+          <button className={styles.primaryButton} type="button">
+            <span aria-hidden className={styles.buttonIcon}>
+              <ScanGlyphIcon />
+            </span>
+            QR 스캔하기
+          </button>
+
+          <button className={styles.secondaryButton} type="button">
+            <span aria-hidden className={styles.buttonIcon}>
+              <UploadGlyphIcon />
+            </span>
+            갤러리에서 업로드
+          </button>
+        </section>
+
+        <section aria-labelledby="recent-scan-title" className={styles.historySection}>
+          <div className={styles.sectionHeader}>
+            <h2 className={styles.sectionTitle} id="recent-scan-title">
+              최근 스캔 기록
+            </h2>
+            <Link className={styles.viewAllLink} to="/scan-history">
+              전체보기
+            </Link>
+          </div>
+
+          <article className={styles.historyCard}>
+            <span className={styles.historyBadge}>
+              <span aria-hidden className={styles.historyBadgeIcon}>
+                <ViewGlyphIcon />
+              </span>
+              {recentScanRecord.statusLabel}
+            </span>
+
+            <p className={styles.historyDate}>{recentScanRecord.scannedAt}</p>
+            <p className={styles.historyUrl}>{recentScanRecord.url}</p>
+            <p className={styles.historyStatus}>{recentScanRecord.summary}</p>
+          </article>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/pages/QRScan/QRScanPage.tsx
+++ b/src/pages/QRScan/QRScanPage.tsx
@@ -3,14 +3,8 @@ import { Link } from '@tanstack/react-router';
 import { qrIconByTone } from '@/shared/icon/resultIcons';
 import AppHeader from '@/shared/ui/app-header';
 
+import { useQRScanPage } from './hooks/useQRScanPage';
 import * as styles from './styles/qrScanPage.css';
-
-const recentScanRecord = {
-  scannedAt: '2023.10.27 14:32',
-  statusLabel: 'SAFE',
-  summary: '위험 요소가 발견되지 않았습니다.',
-  url: 'https://www.naver.com/',
-};
 
 function ScanGlyphIcon() {
   return (
@@ -56,40 +50,91 @@ function ViewGlyphIcon() {
 }
 
 export default function QRScanPage() {
+  const {
+    cameraStatus,
+    cameraStatusText,
+    captureRecord,
+    fileInputRef,
+    handleCapturePhoto,
+    handleGalleryFileChange,
+    handleOpenGallery,
+    isCapturing,
+    isFlashVisible,
+    videoRef,
+  } = useQRScanPage();
+
+  const recentActivity = captureRecord ?? {
+    badgeLabel: 'LIVE',
+    capturedAt:
+      cameraStatus === 'ready' ? '실시간 프리뷰 활성화됨' : '카메라 연결을 확인해 주세요.',
+    headline:
+      cameraStatus === 'ready'
+        ? '후면 카메라 화면이 실시간으로 표시되고 있습니다.'
+        : '후면 카메라 연결 후 현재 화면을 촬영할 수 있습니다.',
+    photoUrl: null,
+    summary:
+      cameraStatus === 'ready'
+        ? '초록색 버튼을 누르면 현재 후면 카메라 프레임이 촬영됩니다.'
+        : cameraStatusText,
+  };
+
   return (
     <main className={styles.page}>
       <AppHeader iconSrc={qrIconByTone.safe} />
 
       <div className={styles.shell}>
         <section className={styles.heroSection}>
-          <div aria-hidden className={styles.scanStage}>
+          <div className={styles.scanStage}>
+            <video
+              aria-label="후면 카메라 미리보기"
+              autoPlay
+              className={styles.cameraPreview}
+              muted
+              playsInline
+              ref={videoRef}
+            />
             <div className={styles.scanBackdrop} />
 
-            <div className={styles.handSilhouette}>
-              <div className={styles.handPalm} />
-              <div className={styles.handThumb} />
+            <div
+              className={`${styles.cameraLiveBadge} ${styles.cameraLiveBadgeTone[cameraStatus]}`}
+            >
+              <span className={styles.cameraLiveDot} />
+              {cameraStatus === 'ready'
+                ? 'REAR CAMERA'
+                : cameraStatus === 'loading'
+                  ? 'CONNECTING'
+                  : 'CAMERA ERROR'}
             </div>
 
-            <div className={styles.device}>
-              <div className={styles.deviceSpeaker} />
-
-              <div className={styles.deviceScreen}>
-                <div className={styles.deviceQrGhost} />
-                <div className={styles.deviceTextLine} />
-                <div className={styles.deviceTextLineShort} />
+            {cameraStatus !== 'ready' ? (
+              <div
+                className={`${styles.cameraFallback} ${styles.cameraFallbackTone[cameraStatus]}`}
+              >
+                <p className={styles.cameraFallbackTitle}>
+                  {cameraStatus === 'loading' ? '후면 카메라 연결 중' : '카메라 연결 필요'}
+                </p>
+                <p className={styles.cameraFallbackDescription}>{cameraStatusText}</p>
               </div>
+            ) : null}
 
-              <div className={styles.deviceFooter}>
-                <span className={styles.deviceFooterDot} />
-                <span className={styles.deviceFooterDot} />
-                <span className={styles.deviceFooterDot} />
-              </div>
-            </div>
+            <div
+              className={
+                cameraStatus === 'ready'
+                  ? styles.scanLine
+                  : `${styles.scanLine} ${styles.scanLineHidden}`
+              }
+            />
 
-            <div className={styles.scanLine} />
+            <div
+              className={
+                isFlashVisible
+                  ? `${styles.captureFlash} ${styles.captureFlashVisible}`
+                  : styles.captureFlash
+              }
+            />
 
             <div className={styles.centerBadge}>
-              <span className={styles.buttonIcon}>
+              <span aria-hidden className={styles.buttonIcon}>
                 <ScanGlyphIcon />
               </span>
             </div>
@@ -103,23 +148,48 @@ export default function QRScanPage() {
           <header className={styles.intro}>
             <h1 className={styles.title}>QR 스캔하기</h1>
             <p className={styles.description}>안전한 스캔을 위해 QR을 프레임 안에 맞춰 주세요</p>
+            <p className={`${styles.cameraStatusText} ${styles.cameraStatusTone[cameraStatus]}`}>
+              {cameraStatusText}
+            </p>
           </header>
         </section>
 
         <section aria-label="QR 스캔 시작" className={styles.actionSection}>
-          <button className={styles.primaryButton} type="button">
+          <button
+            aria-label={
+              cameraStatus === 'ready' ? '현재 카메라 화면 촬영하기' : '후면 카메라 연결하기'
+            }
+            className={styles.primaryButton}
+            disabled={isCapturing || cameraStatus === 'loading'}
+            onClick={() => {
+              void handleCapturePhoto();
+            }}
+            type="button"
+          >
             <span aria-hidden className={styles.buttonIcon}>
               <ScanGlyphIcon />
             </span>
-            QR 스캔하기
+            {isCapturing ? '촬영 중...' : 'QR 스캔하기'}
           </button>
 
-          <button className={styles.secondaryButton} type="button">
+          <button className={styles.secondaryButton} onClick={handleOpenGallery} type="button">
             <span aria-hidden className={styles.buttonIcon}>
               <UploadGlyphIcon />
             </span>
             갤러리에서 업로드
           </button>
+
+          <input
+            accept="image/*"
+            hidden
+            onChange={handleGalleryFileChange}
+            ref={fileInputRef}
+            type="file"
+          />
+
+          <p className={styles.helperText}>
+            라이브 카메라 프리뷰가 준비되면 초록색 버튼으로 현재 화면을 바로 촬영할 수 있습니다.
+          </p>
         </section>
 
         <section aria-labelledby="recent-scan-title" className={styles.historySection}>
@@ -137,12 +207,22 @@ export default function QRScanPage() {
               <span aria-hidden className={styles.historyBadgeIcon}>
                 <ViewGlyphIcon />
               </span>
-              {recentScanRecord.statusLabel}
+              {recentActivity.badgeLabel}
             </span>
 
-            <p className={styles.historyDate}>{recentScanRecord.scannedAt}</p>
-            <p className={styles.historyUrl}>{recentScanRecord.url}</p>
-            <p className={styles.historyStatus}>{recentScanRecord.summary}</p>
+            <p className={styles.historyDate}>{recentActivity.capturedAt}</p>
+            <p className={styles.historyHeadline}>{recentActivity.headline}</p>
+            <p className={styles.historyStatus}>{recentActivity.summary}</p>
+
+            {recentActivity.photoUrl ? (
+              <div className={styles.historyThumbnail}>
+                <img
+                  alt="최근 촬영 또는 업로드한 이미지 미리보기"
+                  className={styles.historyThumbnailImage}
+                  src={recentActivity.photoUrl}
+                />
+              </div>
+            ) : null}
           </article>
         </section>
       </div>

--- a/src/pages/QRScan/hooks/useQRScanPage.ts
+++ b/src/pages/QRScan/hooks/useQRScanPage.ts
@@ -1,0 +1,311 @@
+import type { ChangeEvent, RefObject } from 'react';
+
+import { App } from 'antd';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type CameraStatus = 'loading' | 'ready' | 'error';
+
+type CaptureRecord = {
+  badgeLabel: 'SHOT' | 'UPLOAD';
+  capturedAt: string;
+  headline: string;
+  photoUrl: string;
+  summary: string;
+};
+
+type UseQRScanPageReturn = {
+  cameraStatus: CameraStatus;
+  cameraStatusText: string;
+  captureRecord: CaptureRecord | null;
+  fileInputRef: RefObject<HTMLInputElement | null>;
+  handleCapturePhoto: () => Promise<void>;
+  handleGalleryFileChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  handleOpenGallery: () => void;
+  isCapturing: boolean;
+  isFlashVisible: boolean;
+  videoRef: RefObject<HTMLVideoElement | null>;
+};
+
+function formatCapturedAt(date: Date) {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  const hours = `${date.getHours()}`.padStart(2, '0');
+  const minutes = `${date.getMinutes()}`.padStart(2, '0');
+
+  return `${year}.${month}.${day} ${hours}:${minutes}`;
+}
+
+function revokeObjectUrl(photoUrl: string | null) {
+  if (!photoUrl) {
+    return;
+  }
+
+  URL.revokeObjectURL(photoUrl);
+}
+
+function stopMediaStream(stream: MediaStream | null) {
+  if (!stream) {
+    return;
+  }
+
+  stream.getTracks().forEach((track) => {
+    track.stop();
+  });
+}
+
+function resolveCameraErrorMessage(error: unknown) {
+  if (error instanceof DOMException) {
+    if (error.name === 'NotAllowedError') {
+      return '카메라 권한이 거부되었습니다. 브라우저 설정에서 카메라 권한을 허용해 주세요.';
+    }
+
+    if (error.name === 'NotFoundError' || error.name === 'OverconstrainedError') {
+      return '사용 가능한 후면 카메라를 찾지 못했습니다. 다른 카메라로 다시 시도해 주세요.';
+    }
+
+    if (error.name === 'NotReadableError') {
+      return '카메라가 다른 앱에서 사용 중입니다. 잠시 후 다시 시도해 주세요.';
+    }
+  }
+
+  return '카메라를 시작하지 못했습니다. 권한과 기기 연결 상태를 확인해 주세요.';
+}
+
+async function requestCameraStream() {
+  const rearCameraConstraints: MediaStreamConstraints = {
+    audio: false,
+    video: {
+      facingMode: {
+        ideal: 'environment',
+      },
+      height: {
+        ideal: 1280,
+      },
+      width: {
+        ideal: 720,
+      },
+    },
+  };
+
+  try {
+    return await navigator.mediaDevices.getUserMedia(rearCameraConstraints);
+  } catch (error) {
+    if (
+      error instanceof DOMException &&
+      (error.name === 'OverconstrainedError' || error.name === 'NotFoundError')
+    ) {
+      return navigator.mediaDevices.getUserMedia({
+        audio: false,
+        video: true,
+      });
+    }
+
+    throw error;
+  }
+}
+
+export function useQRScanPage(): UseQRScanPageReturn {
+  const { message } = App.useApp();
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const latestPhotoUrlRef = useRef<string | null>(null);
+  const flashTimerRef = useRef<number | null>(null);
+  const isMountedRef = useRef(true);
+  const [cameraStatus, setCameraStatus] = useState<CameraStatus>('loading');
+  const [cameraStatusText, setCameraStatusText] = useState('후면 카메라를 연결하는 중입니다.');
+  const [captureRecord, setCaptureRecord] = useState<CaptureRecord | null>(null);
+  const [isCapturing, setIsCapturing] = useState(false);
+  const [isFlashVisible, setIsFlashVisible] = useState(false);
+
+  const triggerCaptureFlash = useCallback(() => {
+    if (flashTimerRef.current) {
+      window.clearTimeout(flashTimerRef.current);
+    }
+
+    setIsFlashVisible(true);
+    flashTimerRef.current = window.setTimeout(() => {
+      if (isMountedRef.current) {
+        setIsFlashVisible(false);
+      }
+    }, 180);
+  }, []);
+
+  const updateCaptureRecord = useCallback((nextRecord: CaptureRecord) => {
+    revokeObjectUrl(latestPhotoUrlRef.current);
+    latestPhotoUrlRef.current = nextRecord.photoUrl;
+    setCaptureRecord(nextRecord);
+  }, []);
+
+  const startCamera = useCallback(async () => {
+    if (typeof window === 'undefined' || typeof navigator === 'undefined') {
+      return;
+    }
+
+    if (!window.isSecureContext) {
+      setCameraStatus('error');
+      setCameraStatusText(
+        '카메라 프리뷰는 보안 연결(https 또는 localhost)에서만 사용할 수 있습니다.',
+      );
+      return;
+    }
+
+    if (!navigator.mediaDevices?.getUserMedia) {
+      setCameraStatus('error');
+      setCameraStatusText('이 브라우저는 카메라 프리뷰를 지원하지 않습니다.');
+      return;
+    }
+
+    setCameraStatus('loading');
+    setCameraStatusText('후면 카메라를 연결하는 중입니다.');
+
+    try {
+      const nextStream = await requestCameraStream();
+
+      if (!isMountedRef.current) {
+        stopMediaStream(nextStream);
+        return;
+      }
+
+      stopMediaStream(streamRef.current);
+      streamRef.current = nextStream;
+
+      const videoElement = videoRef.current;
+
+      if (videoElement) {
+        videoElement.srcObject = nextStream;
+
+        try {
+          await videoElement.play();
+        } catch (error) {
+          console.warn('Failed to start camera preview playback.', error);
+        }
+      }
+
+      setCameraStatus('ready');
+      setCameraStatusText('후면 카메라가 연결되었습니다. 버튼을 눌러 현재 화면을 촬영하세요.');
+    } catch (error) {
+      console.error('Failed to start QR camera preview.', error);
+
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      setCameraStatus('error');
+      setCameraStatusText(resolveCameraErrorMessage(error));
+    }
+  }, []);
+
+  useEffect(() => {
+    void startCamera();
+
+    return () => {
+      isMountedRef.current = false;
+
+      if (flashTimerRef.current) {
+        window.clearTimeout(flashTimerRef.current);
+      }
+
+      revokeObjectUrl(latestPhotoUrlRef.current);
+      stopMediaStream(streamRef.current);
+    };
+  }, [startCamera]);
+
+  const handleCapturePhoto = useCallback(async () => {
+    if (cameraStatus !== 'ready') {
+      await startCamera();
+      return;
+    }
+
+    const videoElement = videoRef.current;
+
+    if (!videoElement || videoElement.videoWidth === 0 || videoElement.videoHeight === 0) {
+      message.warning('카메라 준비가 아직 완료되지 않았습니다. 잠시 후 다시 시도해 주세요.');
+      return;
+    }
+
+    setIsCapturing(true);
+
+    try {
+      const canvas = document.createElement('canvas');
+      canvas.width = videoElement.videoWidth;
+      canvas.height = videoElement.videoHeight;
+
+      const context = canvas.getContext('2d');
+
+      if (!context) {
+        message.error('사진 촬영을 준비하지 못했습니다. 다시 시도해 주세요.');
+        return;
+      }
+
+      context.drawImage(videoElement, 0, 0, canvas.width, canvas.height);
+
+      const photoBlob = await new Promise<Blob | null>((resolve) => {
+        canvas.toBlob(resolve, 'image/jpeg', 0.92);
+      });
+
+      if (!photoBlob) {
+        message.error('사진 파일을 만들지 못했습니다. 다시 시도해 주세요.');
+        return;
+      }
+
+      const capturedAt = formatCapturedAt(new Date());
+      const photoUrl = URL.createObjectURL(photoBlob);
+
+      updateCaptureRecord({
+        badgeLabel: 'SHOT',
+        capturedAt,
+        headline: '후면 카메라 프레임을 촬영했습니다.',
+        photoUrl,
+        summary: '현재 화면을 캡처해 최근 기록에 반영했습니다.',
+      });
+      triggerCaptureFlash();
+      message.success('사진을 촬영했습니다.');
+    } finally {
+      if (isMountedRef.current) {
+        setIsCapturing(false);
+      }
+    }
+  }, [cameraStatus, message, startCamera, triggerCaptureFlash, updateCaptureRecord]);
+
+  const handleOpenGallery = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
+  const handleGalleryFileChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const selectedFile = event.target.files?.[0];
+
+      if (!selectedFile) {
+        return;
+      }
+
+      const photoUrl = URL.createObjectURL(selectedFile);
+
+      updateCaptureRecord({
+        badgeLabel: 'UPLOAD',
+        capturedAt: formatCapturedAt(new Date()),
+        headline: selectedFile.name,
+        photoUrl,
+        summary: '갤러리 이미지를 불러와 최근 기록에 반영했습니다.',
+      });
+      message.success('갤러리 이미지를 불러왔습니다.');
+      event.target.value = '';
+    },
+    [message, updateCaptureRecord],
+  );
+
+  return {
+    cameraStatus,
+    cameraStatusText,
+    captureRecord,
+    fileInputRef,
+    handleCapturePhoto,
+    handleGalleryFileChange,
+    handleOpenGallery,
+    isCapturing,
+    isFlashVisible,
+    videoRef,
+  };
+}

--- a/src/pages/QRScan/hooks/useQRScanPage.ts
+++ b/src/pages/QRScan/hooks/useQRScanPage.ts
@@ -198,6 +198,7 @@ export function useQRScanPage(): UseQRScanPageReturn {
   }, []);
 
   useEffect(() => {
+    isMountedRef.current = true;
     void startCamera();
 
     return () => {

--- a/src/pages/QRScan/index.ts
+++ b/src/pages/QRScan/index.ts
@@ -1,0 +1,1 @@
+export { default } from './QRScanPage';

--- a/src/pages/QRScan/styles/qrScanPage.css.ts
+++ b/src/pages/QRScan/styles/qrScanPage.css.ts
@@ -1,0 +1,441 @@
+import { keyframes, style } from '@vanilla-extract/css';
+
+import { vars } from '@/vars.css';
+
+const bpTablet = 'screen and (min-width: 768px)';
+
+const scanLineMotion = keyframes({
+  '0%': {
+    opacity: 0.6,
+    transform: 'translateY(-54px)',
+  },
+  '50%': {
+    opacity: 1,
+    transform: 'translateY(28px)',
+  },
+  '100%': {
+    opacity: 0.6,
+    transform: 'translateY(-54px)',
+  },
+});
+
+export const page = style({
+  minHeight: '100vh',
+  backgroundColor: vars.colors.white,
+});
+
+export const shell = style({
+  boxSizing: 'border-box',
+  width: '100%',
+  maxWidth: '420px',
+  margin: '0 auto',
+  padding: `20px ${vars.spacing.md} 48px`,
+  display: 'grid',
+  gap: '28px',
+  '@media': {
+    [bpTablet]: {
+      maxWidth: '480px',
+      padding: `28px ${vars.spacing.xl} 56px`,
+      gap: vars.spacing.xl,
+    },
+  },
+});
+
+export const heroSection = style({
+  display: 'grid',
+  gap: vars.spacing.lg,
+});
+
+export const scanStage = style({
+  position: 'relative',
+  minHeight: '246px',
+  borderRadius: '28px',
+  overflow: 'hidden',
+  background:
+    'linear-gradient(180deg, rgba(250, 251, 253, 0.98) 0%, rgba(239, 242, 246, 0.98) 100%)',
+  boxShadow: 'inset 0 0 0 1px rgba(15, 23, 42, 0.04)',
+  isolation: 'isolate',
+});
+
+export const scanBackdrop = style({
+  position: 'absolute',
+  inset: 0,
+  background: `
+    radial-gradient(circle at 50% 28%, rgba(17, 212, 131, 0.14), transparent 26%),
+    radial-gradient(circle at 26% 84%, rgba(255, 255, 255, 0.85), transparent 36%),
+    radial-gradient(circle at 88% 78%, rgba(232, 236, 242, 0.9), transparent 22%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.52), rgba(242, 245, 249, 0.82))
+  `,
+});
+
+export const handSilhouette = style({
+  position: 'absolute',
+  inset: '58px 22px 18px 22px',
+  opacity: 0.3,
+  filter: 'blur(0.4px)',
+});
+
+export const handPalm = style({
+  position: 'absolute',
+  left: '12%',
+  right: '12%',
+  bottom: '8%',
+  height: '56%',
+  borderRadius: '40% 42% 26% 30%',
+  background:
+    'linear-gradient(135deg, rgba(229, 214, 201, 0.72) 0%, rgba(240, 227, 214, 0.42) 100%)',
+  transform: 'rotate(-10deg)',
+});
+
+export const handThumb = style({
+  position: 'absolute',
+  left: '10%',
+  bottom: '28%',
+  width: '34%',
+  height: '18%',
+  borderRadius: '999px',
+  background: 'linear-gradient(90deg, rgba(231, 216, 204, 0.66), rgba(245, 236, 226, 0.28))',
+  transform: 'rotate(-28deg)',
+});
+
+export const device = style({
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  width: '92px',
+  height: '160px',
+  borderRadius: '18px',
+  transform: 'translate(-50%, -50%)',
+  background: 'linear-gradient(180deg, #dbe6f2 0%, #c3d1df 100%)',
+  boxShadow: '0 18px 36px rgba(58, 77, 98, 0.2)',
+  overflow: 'hidden',
+});
+
+export const deviceSpeaker = style({
+  position: 'absolute',
+  top: '10px',
+  left: '50%',
+  width: '32px',
+  height: '5px',
+  borderRadius: '999px',
+  backgroundColor: 'rgba(59, 69, 82, 0.35)',
+  transform: 'translateX(-50%)',
+});
+
+export const deviceScreen = style({
+  position: 'absolute',
+  top: '22px',
+  left: '8px',
+  right: '8px',
+  bottom: '24px',
+  borderRadius: '8px',
+  padding: '14px 10px',
+  display: 'grid',
+  alignContent: 'start',
+  justifyItems: 'center',
+  gap: '10px',
+  background: 'linear-gradient(180deg, #f9fbff 0%, #eef4fb 100%)',
+  boxShadow: 'inset 0 0 0 1px rgba(189, 204, 221, 0.6)',
+});
+
+export const deviceQrGhost = style({
+  width: '42px',
+  height: '42px',
+  borderRadius: vars.radius.md,
+  background: `
+    linear-gradient(90deg, rgba(163, 180, 198, 0.55) 0 22%, transparent 22% 28%, rgba(163, 180, 198, 0.55) 28% 50%, transparent 50% 56%, rgba(163, 180, 198, 0.55) 56% 78%, transparent 78% 100%),
+    linear-gradient(rgba(163, 180, 198, 0.55) 0 22%, transparent 22% 28%, rgba(163, 180, 198, 0.55) 28% 50%, transparent 50% 56%, rgba(163, 180, 198, 0.55) 56% 78%, transparent 78% 100%)
+  `,
+  opacity: 0.8,
+});
+
+export const deviceTextLine = style({
+  width: '100%',
+  height: '10px',
+  borderRadius: '999px',
+  backgroundColor: 'rgba(189, 204, 221, 0.76)',
+});
+
+export const deviceTextLineShort = style([
+  deviceTextLine,
+  {
+    width: '70%',
+    justifySelf: 'start',
+  },
+]);
+
+export const deviceFooter = style({
+  position: 'absolute',
+  left: '50%',
+  bottom: '10px',
+  display: 'inline-flex',
+  gap: '10px',
+  transform: 'translateX(-50%)',
+});
+
+export const deviceFooterDot = style({
+  width: '4px',
+  height: '4px',
+  borderRadius: '999px',
+  backgroundColor: 'rgba(246, 248, 251, 0.76)',
+});
+
+export const scanLine = style({
+  position: 'absolute',
+  left: '14%',
+  right: '14%',
+  top: '50%',
+  height: '4px',
+  borderRadius: '999px',
+  background:
+    'linear-gradient(90deg, rgba(17, 212, 131, 0) 0%, rgba(17, 212, 131, 0.9) 24%, rgba(17, 212, 131, 1) 50%, rgba(17, 212, 131, 0.9) 76%, rgba(17, 212, 131, 0) 100%)',
+  boxShadow: '0 0 18px rgba(17, 212, 131, 0.55)',
+  animation: `${scanLineMotion} 3s ease-in-out infinite`,
+});
+
+export const centerBadge = style({
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  width: '76px',
+  height: '76px',
+  display: 'grid',
+  placeItems: 'center',
+  borderRadius: '999px',
+  backgroundColor: 'rgba(255, 255, 255, 0.9)',
+  boxShadow: '0 14px 30px rgba(105, 124, 147, 0.22)',
+  transform: 'translate(-50%, -50%)',
+});
+
+export const scanCorner = style({
+  position: 'absolute',
+  width: '28px',
+  height: '28px',
+  borderColor: vars.colors.success,
+  borderStyle: 'solid',
+  borderWidth: '0',
+});
+
+export const scanCornerTopLeft = style({
+  top: '18px',
+  left: '20px',
+  borderTopWidth: '4px',
+  borderLeftWidth: '4px',
+  borderTopLeftRadius: '24px',
+});
+
+export const scanCornerTopRight = style({
+  top: '18px',
+  right: '20px',
+  borderTopWidth: '4px',
+  borderRightWidth: '4px',
+  borderTopRightRadius: '24px',
+});
+
+export const scanCornerBottomLeft = style({
+  bottom: '22px',
+  left: '20px',
+  borderBottomWidth: '4px',
+  borderLeftWidth: '4px',
+  borderBottomLeftRadius: '24px',
+});
+
+export const scanCornerBottomRight = style({
+  right: '20px',
+  bottom: '22px',
+  borderRightWidth: '4px',
+  borderBottomWidth: '4px',
+  borderBottomRightRadius: '24px',
+});
+
+export const intro = style({
+  display: 'grid',
+  gap: vars.spacing.sm,
+  justifyItems: 'center',
+  textAlign: 'center',
+});
+
+export const title = style({
+  margin: 0,
+  color: vars.colors.black,
+  fontSize: '30px',
+  fontWeight: vars.font.weight.bold,
+  lineHeight: 1.2,
+});
+
+export const description = style({
+  margin: 0,
+  color: vars.colors.subText,
+  fontSize: vars.font.size.md,
+  lineHeight: 1.5,
+});
+
+export const actionSection = style({
+  display: 'grid',
+  gap: vars.spacing.sm,
+});
+
+export const actionButton = style({
+  width: '100%',
+  minHeight: '56px',
+  borderRadius: '999px',
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: vars.spacing.sm,
+  fontSize: vars.font.size.md,
+  fontWeight: vars.font.weight.semibold,
+  cursor: 'pointer',
+  transition:
+    'transform 160ms ease, box-shadow 160ms ease, background-color 160ms ease, border-color 160ms ease',
+  selectors: {
+    '&:hover': {
+      transform: 'translateY(-1px)',
+    },
+    '&:focus-visible': {
+      outline: `3px solid ${vars.colors.mainLightHover}`,
+      outlineOffset: '2px',
+    },
+  },
+});
+
+export const primaryButton = style([
+  actionButton,
+  {
+    border: 'none',
+    color: vars.colors.white,
+    backgroundColor: vars.colors.success,
+    boxShadow: '0 12px 28px rgba(17, 212, 131, 0.28)',
+    selectors: {
+      '&:hover': {
+        backgroundColor: '#0fbe75',
+      },
+      '&:focus-visible': {
+        outline: `3px solid ${vars.colors.mainLightHover}`,
+        outlineOffset: '2px',
+      },
+    },
+  },
+]);
+
+export const secondaryButton = style([
+  actionButton,
+  {
+    border: '1px solid rgba(11, 11, 11, 0.08)',
+    color: vars.colors.subText,
+    backgroundColor: vars.colors.white,
+    boxShadow: '0 10px 20px rgba(15, 23, 42, 0.04)',
+    selectors: {
+      '&:hover': {
+        backgroundColor: '#fbfbfc',
+        borderColor: 'rgba(17, 212, 131, 0.22)',
+      },
+      '&:focus-visible': {
+        outline: `3px solid ${vars.colors.mainLightHover}`,
+        outlineOffset: '2px',
+      },
+    },
+  },
+]);
+
+export const buttonIcon = style({
+  width: '18px',
+  height: '18px',
+  display: 'inline-flex',
+  flexShrink: 0,
+});
+
+export const historySection = style({
+  display: 'grid',
+  gap: vars.spacing.md,
+});
+
+export const sectionHeader = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: vars.spacing.sm,
+});
+
+export const sectionTitle = style({
+  margin: 0,
+  color: vars.colors.black,
+  fontSize: vars.font.size.lg,
+  fontWeight: vars.font.weight.bold,
+});
+
+export const viewAllLink = style({
+  color: vars.colors.success,
+  fontSize: vars.font.size.xs,
+  fontWeight: vars.font.weight.semibold,
+  textDecoration: 'none',
+  selectors: {
+    '&:hover': {
+      textDecoration: 'underline',
+    },
+    '&:focus-visible': {
+      outline: `2px solid ${vars.colors.mainLightHover}`,
+      outlineOffset: '3px',
+      borderRadius: vars.radius.sm,
+    },
+  },
+});
+
+export const historyCard = style({
+  position: 'relative',
+  display: 'grid',
+  gap: vars.spacing.sm,
+  padding: '18px 16px 16px',
+  borderRadius: '16px',
+  backgroundColor: '#eef2f6',
+  boxShadow: 'inset 0 0 0 1px rgba(148, 163, 184, 0.08)',
+});
+
+export const historyBadge = style({
+  position: 'absolute',
+  top: 0,
+  right: 0,
+  minWidth: '86px',
+  height: '28px',
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '6px',
+  padding: '0 12px',
+  borderRadius: '0 16px 0 16px',
+  backgroundColor: vars.colors.success,
+  color: vars.colors.white,
+  fontSize: '11px',
+  fontWeight: vars.font.weight.bold,
+  letterSpacing: '0.18em',
+});
+
+export const historyBadgeIcon = style({
+  width: '12px',
+  height: '12px',
+  display: 'inline-flex',
+});
+
+export const historyDate = style({
+  margin: 0,
+  color: '#6b7280',
+  fontSize: '11px',
+  fontWeight: vars.font.weight.medium,
+});
+
+export const historyUrl = style({
+  margin: 0,
+  color: vars.colors.black,
+  fontSize: vars.font.size.md,
+  fontWeight: vars.font.weight.bold,
+  lineHeight: 1.45,
+  wordBreak: 'break-all',
+});
+
+export const historyStatus = style({
+  margin: 0,
+  color: vars.colors.success,
+  fontSize: '12px',
+  fontWeight: vars.font.weight.medium,
+  lineHeight: 1.4,
+});

--- a/src/pages/QRScan/styles/qrScanPage.css.ts
+++ b/src/pages/QRScan/styles/qrScanPage.css.ts
@@ -1,4 +1,4 @@
-import { keyframes, style } from '@vanilla-extract/css';
+import { keyframes, style, styleVariants } from '@vanilla-extract/css';
 
 import { vars } from '@/vars.css';
 
@@ -6,16 +6,16 @@ const bpTablet = 'screen and (min-width: 768px)';
 
 const scanLineMotion = keyframes({
   '0%': {
-    opacity: 0.6,
-    transform: 'translateY(-54px)',
+    opacity: 0.45,
+    transform: 'translateY(-62px)',
   },
   '50%': {
     opacity: 1,
-    transform: 'translateY(28px)',
+    transform: 'translateY(32px)',
   },
   '100%': {
-    opacity: 0.6,
-    transform: 'translateY(-54px)',
+    opacity: 0.45,
+    transform: 'translateY(-62px)',
   },
 });
 
@@ -51,133 +51,105 @@ export const scanStage = style({
   minHeight: '246px',
   borderRadius: '28px',
   overflow: 'hidden',
-  background:
-    'linear-gradient(180deg, rgba(250, 251, 253, 0.98) 0%, rgba(239, 242, 246, 0.98) 100%)',
-  boxShadow: 'inset 0 0 0 1px rgba(15, 23, 42, 0.04)',
+  backgroundColor: '#09131a',
+  boxShadow: 'inset 0 0 0 1px rgba(255, 255, 255, 0.06)',
   isolation: 'isolate',
+});
+
+export const cameraPreview = style({
+  position: 'absolute',
+  inset: 0,
+  width: '100%',
+  height: '100%',
+  objectFit: 'cover',
+  backgroundColor: '#0b1220',
 });
 
 export const scanBackdrop = style({
   position: 'absolute',
   inset: 0,
   background: `
-    radial-gradient(circle at 50% 28%, rgba(17, 212, 131, 0.14), transparent 26%),
-    radial-gradient(circle at 26% 84%, rgba(255, 255, 255, 0.85), transparent 36%),
-    radial-gradient(circle at 88% 78%, rgba(232, 236, 242, 0.9), transparent 22%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.52), rgba(242, 245, 249, 0.82))
+    radial-gradient(circle at 50% 24%, rgba(17, 212, 131, 0.18), transparent 26%),
+    linear-gradient(180deg, rgba(6, 11, 15, 0.16) 0%, rgba(6, 11, 15, 0.28) 100%)
   `,
 });
 
-export const handSilhouette = style({
+export const cameraLiveBadge = style({
   position: 'absolute',
-  inset: '58px 22px 18px 22px',
-  opacity: 0.3,
-  filter: 'blur(0.4px)',
-});
-
-export const handPalm = style({
-  position: 'absolute',
-  left: '12%',
-  right: '12%',
-  bottom: '8%',
-  height: '56%',
-  borderRadius: '40% 42% 26% 30%',
-  background:
-    'linear-gradient(135deg, rgba(229, 214, 201, 0.72) 0%, rgba(240, 227, 214, 0.42) 100%)',
-  transform: 'rotate(-10deg)',
-});
-
-export const handThumb = style({
-  position: 'absolute',
-  left: '10%',
-  bottom: '28%',
-  width: '34%',
-  height: '18%',
-  borderRadius: '999px',
-  background: 'linear-gradient(90deg, rgba(231, 216, 204, 0.66), rgba(245, 236, 226, 0.28))',
-  transform: 'rotate(-28deg)',
-});
-
-export const device = style({
-  position: 'absolute',
-  top: '50%',
-  left: '50%',
-  width: '92px',
-  height: '160px',
-  borderRadius: '18px',
-  transform: 'translate(-50%, -50%)',
-  background: 'linear-gradient(180deg, #dbe6f2 0%, #c3d1df 100%)',
-  boxShadow: '0 18px 36px rgba(58, 77, 98, 0.2)',
-  overflow: 'hidden',
-});
-
-export const deviceSpeaker = style({
-  position: 'absolute',
-  top: '10px',
-  left: '50%',
-  width: '32px',
-  height: '5px',
-  borderRadius: '999px',
-  backgroundColor: 'rgba(59, 69, 82, 0.35)',
-  transform: 'translateX(-50%)',
-});
-
-export const deviceScreen = style({
-  position: 'absolute',
-  top: '22px',
-  left: '8px',
-  right: '8px',
-  bottom: '24px',
-  borderRadius: '8px',
-  padding: '14px 10px',
-  display: 'grid',
-  alignContent: 'start',
-  justifyItems: 'center',
-  gap: '10px',
-  background: 'linear-gradient(180deg, #f9fbff 0%, #eef4fb 100%)',
-  boxShadow: 'inset 0 0 0 1px rgba(189, 204, 221, 0.6)',
-});
-
-export const deviceQrGhost = style({
-  width: '42px',
-  height: '42px',
-  borderRadius: vars.radius.md,
-  background: `
-    linear-gradient(90deg, rgba(163, 180, 198, 0.55) 0 22%, transparent 22% 28%, rgba(163, 180, 198, 0.55) 28% 50%, transparent 50% 56%, rgba(163, 180, 198, 0.55) 56% 78%, transparent 78% 100%),
-    linear-gradient(rgba(163, 180, 198, 0.55) 0 22%, transparent 22% 28%, rgba(163, 180, 198, 0.55) 28% 50%, transparent 50% 56%, rgba(163, 180, 198, 0.55) 56% 78%, transparent 78% 100%)
-  `,
-  opacity: 0.8,
-});
-
-export const deviceTextLine = style({
-  width: '100%',
-  height: '10px',
-  borderRadius: '999px',
-  backgroundColor: 'rgba(189, 204, 221, 0.76)',
-});
-
-export const deviceTextLineShort = style([
-  deviceTextLine,
-  {
-    width: '70%',
-    justifySelf: 'start',
-  },
-]);
-
-export const deviceFooter = style({
-  position: 'absolute',
-  left: '50%',
-  bottom: '10px',
+  top: '16px',
+  left: '16px',
+  zIndex: 1,
   display: 'inline-flex',
-  gap: '10px',
-  transform: 'translateX(-50%)',
+  alignItems: 'center',
+  gap: '8px',
+  padding: '8px 12px',
+  borderRadius: '999px',
+  fontSize: '11px',
+  fontWeight: vars.font.weight.bold,
+  letterSpacing: '0.12em',
+  backdropFilter: 'blur(12px)',
 });
 
-export const deviceFooterDot = style({
-  width: '4px',
-  height: '4px',
+export const cameraLiveBadgeTone = styleVariants({
+  error: {
+    backgroundColor: 'rgba(239, 68, 68, 0.18)',
+    color: '#fee2e2',
+  },
+  loading: {
+    backgroundColor: 'rgba(15, 23, 42, 0.42)',
+    color: '#f8fafc',
+  },
+  ready: {
+    backgroundColor: 'rgba(17, 212, 131, 0.18)',
+    color: '#dcfce7',
+  },
+});
+
+export const cameraLiveDot = style({
+  width: '8px',
+  height: '8px',
   borderRadius: '999px',
-  backgroundColor: 'rgba(246, 248, 251, 0.76)',
+  backgroundColor: 'currentColor',
+  boxShadow: '0 0 10px currentColor',
+});
+
+export const cameraFallback = style({
+  position: 'absolute',
+  inset: 0,
+  zIndex: 1,
+  display: 'grid',
+  alignContent: 'center',
+  justifyItems: 'center',
+  gap: vars.spacing.sm,
+  padding: '40px 24px',
+  textAlign: 'center',
+  backdropFilter: 'blur(8px)',
+});
+
+export const cameraFallbackTone = styleVariants({
+  error: {
+    backgroundColor: 'rgba(15, 23, 42, 0.58)',
+  },
+  loading: {
+    backgroundColor: 'rgba(15, 23, 42, 0.42)',
+  },
+  ready: {
+    backgroundColor: 'transparent',
+  },
+});
+
+export const cameraFallbackTitle = style({
+  margin: 0,
+  color: vars.colors.white,
+  fontSize: vars.font.size.lg,
+  fontWeight: vars.font.weight.bold,
+});
+
+export const cameraFallbackDescription = style({
+  margin: 0,
+  color: 'rgba(255, 255, 255, 0.82)',
+  fontSize: vars.font.size.sm,
+  lineHeight: 1.6,
 });
 
 export const scanLine = style({
@@ -185,35 +157,59 @@ export const scanLine = style({
   left: '14%',
   right: '14%',
   top: '50%',
+  zIndex: 1,
   height: '4px',
   borderRadius: '999px',
   background:
     'linear-gradient(90deg, rgba(17, 212, 131, 0) 0%, rgba(17, 212, 131, 0.9) 24%, rgba(17, 212, 131, 1) 50%, rgba(17, 212, 131, 0.9) 76%, rgba(17, 212, 131, 0) 100%)',
   boxShadow: '0 0 18px rgba(17, 212, 131, 0.55)',
   animation: `${scanLineMotion} 3s ease-in-out infinite`,
+  transition: 'opacity 160ms ease',
+});
+
+export const scanLineHidden = style({
+  opacity: 0,
+});
+
+export const captureFlash = style({
+  position: 'absolute',
+  inset: 0,
+  zIndex: 2,
+  opacity: 0,
+  pointerEvents: 'none',
+  backgroundColor: 'rgba(255, 255, 255, 0.7)',
+  transition: 'opacity 140ms ease',
+});
+
+export const captureFlashVisible = style({
+  opacity: 1,
 });
 
 export const centerBadge = style({
   position: 'absolute',
   top: '50%',
   left: '50%',
+  zIndex: 1,
   width: '76px',
   height: '76px',
   display: 'grid',
   placeItems: 'center',
   borderRadius: '999px',
   backgroundColor: 'rgba(255, 255, 255, 0.9)',
-  boxShadow: '0 14px 30px rgba(105, 124, 147, 0.22)',
+  color: vars.colors.success,
+  boxShadow: '0 14px 30px rgba(9, 19, 26, 0.28)',
   transform: 'translate(-50%, -50%)',
 });
 
 export const scanCorner = style({
   position: 'absolute',
+  zIndex: 1,
   width: '28px',
   height: '28px',
   borderColor: vars.colors.success,
   borderStyle: 'solid',
   borderWidth: '0',
+  boxShadow: '0 0 12px rgba(17, 212, 131, 0.2)',
 });
 
 export const scanCornerTopLeft = style({
@@ -270,6 +266,25 @@ export const description = style({
   lineHeight: 1.5,
 });
 
+export const cameraStatusText = style({
+  margin: 0,
+  fontSize: vars.font.size.sm,
+  fontWeight: vars.font.weight.medium,
+  lineHeight: 1.5,
+});
+
+export const cameraStatusTone = styleVariants({
+  error: {
+    color: vars.colors.error,
+  },
+  loading: {
+    color: vars.colors.subDark,
+  },
+  ready: {
+    color: vars.colors.success,
+  },
+});
+
 export const actionSection = style({
   display: 'grid',
   gap: vars.spacing.sm,
@@ -295,6 +310,11 @@ export const actionButton = style({
     '&:focus-visible': {
       outline: `3px solid ${vars.colors.mainLightHover}`,
       outlineOffset: '2px',
+    },
+    '&:disabled': {
+      transform: 'none',
+      opacity: 0.7,
+      cursor: 'wait',
     },
   },
 });
@@ -343,6 +363,14 @@ export const buttonIcon = style({
   height: '18px',
   display: 'inline-flex',
   flexShrink: 0,
+});
+
+export const helperText = style({
+  margin: 0,
+  color: vars.colors.subDark,
+  fontSize: vars.font.size.xs,
+  lineHeight: 1.6,
+  textAlign: 'center',
 });
 
 export const historySection = style({
@@ -423,13 +451,13 @@ export const historyDate = style({
   fontWeight: vars.font.weight.medium,
 });
 
-export const historyUrl = style({
+export const historyHeadline = style({
   margin: 0,
   color: vars.colors.black,
   fontSize: vars.font.size.md,
   fontWeight: vars.font.weight.bold,
   lineHeight: 1.45,
-  wordBreak: 'break-all',
+  wordBreak: 'keep-all',
 });
 
 export const historyStatus = style({
@@ -438,4 +466,18 @@ export const historyStatus = style({
   fontSize: '12px',
   fontWeight: vars.font.weight.medium,
   lineHeight: 1.4,
+});
+
+export const historyThumbnail = style({
+  overflow: 'hidden',
+  borderRadius: '12px',
+  backgroundColor: '#dbe4ec',
+  aspectRatio: '16 / 9',
+});
+
+export const historyThumbnailImage = style({
+  width: '100%',
+  height: '100%',
+  objectFit: 'cover',
+  display: 'block',
 });

--- a/src/pages/ScanList/ScanListPage.tsx
+++ b/src/pages/ScanList/ScanListPage.tsx
@@ -1,0 +1,136 @@
+import { qrIconByTone } from '@/shared/icon/resultIcons';
+import AppHeader from '@/shared/ui/app-header';
+
+import { useScanListPage } from './hooks/useScanListPage';
+import * as styles from './styles/scanListPage.css';
+
+import type { ScanListStatus } from './types/scanListPage.types';
+
+const statusLabelByTone: Record<ScanListStatus, string> = {
+  safe: '안전',
+  warning: '주의',
+  critical: '위험',
+};
+
+function CalendarIcon() {
+  return (
+    <svg aria-hidden="true" fill="none" viewBox="0 0 16 16">
+      <path
+        d="M5 1.75V3m6-1.25V3M2.75 5.25h10.5M4 7.75h4.5m-5.75 6.5h10.5A1.25 1.25 0 0 0 14.5 13V4.5A1.25 1.25 0 0 0 13.25 3.25H2.75A1.25 1.25 0 0 0 1.5 4.5V13A1.25 1.25 0 0 0 2.75 14.25Z"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.35"
+      />
+    </svg>
+  );
+}
+
+function StatusBadgeIcon({ tone }: { tone: ScanListStatus }) {
+  if (tone === 'safe') {
+    return (
+      <svg aria-hidden="true" fill="none" viewBox="0 0 16 16">
+        <path
+          d="M8 1.75 13 3.7v3.15c0 3.1-2.1 5.95-5 7.4-2.9-1.45-5-4.3-5-7.4V3.7l5-1.95Z"
+          fill="currentColor"
+          opacity="0.2"
+        />
+        <path
+          d="m5.9 8.15 1.35 1.35L10.4 6.35"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.5"
+        />
+      </svg>
+    );
+  }
+
+  if (tone === 'warning') {
+    return (
+      <svg aria-hidden="true" fill="none" viewBox="0 0 16 16">
+        <path
+          d="M8.78 2.77 13.58 11A1 1 0 0 1 12.72 12.5H3.28A1 1 0 0 1 2.42 11l4.8-8.23a1 1 0 0 1 1.56 0Z"
+          fill="currentColor"
+          opacity="0.24"
+        />
+        <path
+          d="M8 5.2v3.25M8 10.85h.01"
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.5"
+        />
+      </svg>
+    );
+  }
+
+  return (
+    <svg aria-hidden="true" fill="none" viewBox="0 0 16 16">
+      <circle cx="8" cy="8" fill="currentColor" opacity="0.2" r="6.25" />
+      <path
+        d="m5.7 5.7 4.6 4.6m0-4.6-4.6 4.6"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.5"
+      />
+    </svg>
+  );
+}
+
+export default function ScanListPage() {
+  const { scanListPageData, scanListUuid } = useScanListPage();
+
+  return (
+    <main className={styles.page}>
+      <AppHeader iconSrc={qrIconByTone.safe} />
+
+      <div className={styles.shell}>
+        <header className={styles.intro}>
+          <h1 className={styles.title}>스캔 이력</h1>
+          <p className={styles.description}>최근 QR 스캔 내역을 확인하세요</p>
+          <p className={styles.helper}>조회 UUID: {scanListUuid}</p>
+        </header>
+
+        <section className={styles.listSection}>
+          {scanListPageData.items.length === 0 ? (
+            <div className={styles.emptyState}>연결된 UUID에 대한 스캔 이력이 없습니다.</div>
+          ) : (
+            <ul className={styles.list}>
+              {scanListPageData.items.map((item) => (
+                <li className={`${styles.card} ${styles.cardTone[item.status]}`} key={item.id}>
+                  <span className={`${styles.badge} ${styles.badgeTone[item.status]}`}>
+                    <span aria-hidden="true" className={styles.badgeIcon}>
+                      <StatusBadgeIcon tone={item.status} />
+                    </span>
+                    {statusLabelByTone[item.status]}
+                  </span>
+
+                  <div className={`${styles.cardIconWrap} ${styles.cardIconWrapTone[item.status]}`}>
+                    <img
+                      alt=""
+                      aria-hidden="true"
+                      className={styles.cardIcon}
+                      src={qrIconByTone[item.status]}
+                    />
+                  </div>
+
+                  <article className={styles.cardContent}>
+                    <p className={styles.cardUrl}>{item.url}</p>
+                    <p className={styles.cardMeta}>
+                      <span aria-hidden="true" className={styles.metaIcon}>
+                        <CalendarIcon />
+                      </span>
+                      {item.scannedAt}
+                    </p>
+                  </article>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/pages/ScanList/api/fetchScanListPageData.ts
+++ b/src/pages/ScanList/api/fetchScanListPageData.ts
@@ -31,8 +31,8 @@ function buildRecentScanListPageData(pageData: ScanListPageData): ScanListPageDa
 }
 
 const mockScanListPageDataByUuid: Record<string, ScanListPageData> = {
-  '550e8400-e29b-41d4-a716-446655440000': {
-    uuid: '550e8400-e29b-41d4-a716-446655440000',
+  [defaultScanListUuid]: {
+    uuid: defaultScanListUuid,
     items: [
       {
         id: '0d6db9a1-4a87-4a62-bc54-8f8af98eb6c1',

--- a/src/pages/ScanList/api/fetchScanListPageData.ts
+++ b/src/pages/ScanList/api/fetchScanListPageData.ts
@@ -1,6 +1,34 @@
 import type { ScanListPageData } from '../types/scanListPage.types';
 
 export const defaultScanListUuid = '550e8400-e29b-41d4-a716-446655440000';
+const maxRecentScanListItemCount = 5;
+
+function resolveScannedAtTimestamp(scannedAt: string) {
+  const normalizedScannedAt = scannedAt.replace(/\./g, '-');
+  const parsedTimestamp = Date.parse(normalizedScannedAt);
+
+  if (Number.isNaN(parsedTimestamp)) {
+    return 0;
+  }
+
+  return parsedTimestamp;
+}
+
+function buildRecentScanListPageData(pageData: ScanListPageData): ScanListPageData {
+  const recentItems = [...pageData.items]
+    .sort((previousItem, nextItem) => {
+      return (
+        resolveScannedAtTimestamp(nextItem.scannedAt) -
+        resolveScannedAtTimestamp(previousItem.scannedAt)
+      );
+    })
+    .slice(0, maxRecentScanListItemCount);
+
+  return {
+    ...pageData,
+    items: recentItems,
+  };
+}
 
 const mockScanListPageDataByUuid: Record<string, ScanListPageData> = {
   '550e8400-e29b-41d4-a716-446655440000': {
@@ -36,6 +64,12 @@ const mockScanListPageDataByUuid: Record<string, ScanListPageData> = {
         status: 'warning',
         url: 'https://www.apple.com',
       },
+      {
+        id: '20d9c8f4-b94d-4878-8bc8-6d0a7df65b4c',
+        scannedAt: '2025.09.18',
+        status: 'safe',
+        url: 'https://www.microsoft.com',
+      },
     ],
   },
   '17b8a3a8-4ae1-4b2c-8a61-9f5f3fce3d77': {
@@ -67,7 +101,7 @@ export async function fetchScanListPageData(uuid: string): Promise<ScanListPageD
   const pageData = mockScanListPageDataByUuid[uuid];
 
   if (pageData) {
-    return Promise.resolve(pageData);
+    return Promise.resolve(buildRecentScanListPageData(pageData));
   }
 
   return Promise.resolve({
@@ -77,10 +111,10 @@ export async function fetchScanListPageData(uuid: string): Promise<ScanListPageD
 }
 
 export function getInitialScanListPageData(uuid: string): ScanListPageData {
-  return (
+  return buildRecentScanListPageData(
     mockScanListPageDataByUuid[uuid] ?? {
       items: [],
       uuid,
-    }
+    },
   );
 }

--- a/src/pages/ScanList/api/fetchScanListPageData.ts
+++ b/src/pages/ScanList/api/fetchScanListPageData.ts
@@ -1,0 +1,86 @@
+import type { ScanListPageData } from '../types/scanListPage.types';
+
+export const defaultScanListUuid = '550e8400-e29b-41d4-a716-446655440000';
+
+const mockScanListPageDataByUuid: Record<string, ScanListPageData> = {
+  '550e8400-e29b-41d4-a716-446655440000': {
+    uuid: '550e8400-e29b-41d4-a716-446655440000',
+    items: [
+      {
+        id: '0d6db9a1-4a87-4a62-bc54-8f8af98eb6c1',
+        scannedAt: '2026.01.13',
+        status: 'safe',
+        url: 'https://www.naver.com',
+      },
+      {
+        id: '5d695db5-bd3f-4d57-a88c-ef8c7b8038f0',
+        scannedAt: '2025.12.15',
+        status: 'safe',
+        url: 'https://www.google.com',
+      },
+      {
+        id: 'c97a4156-48f6-47a4-b7c2-2dcd7256190e',
+        scannedAt: '2025.11.23',
+        status: 'critical',
+        url: 'https://www.youtube.com',
+      },
+      {
+        id: '3c6baf44-1f4b-4fb1-835a-7365fe5f16b8',
+        scannedAt: '2025.10.23',
+        status: 'warning',
+        url: 'https://www.daum.net',
+      },
+      {
+        id: '8ea1aa3d-af6d-4f28-bad4-aa1b1f58094d',
+        scannedAt: '2025.10.12',
+        status: 'warning',
+        url: 'https://www.apple.com',
+      },
+    ],
+  },
+  '17b8a3a8-4ae1-4b2c-8a61-9f5f3fce3d77': {
+    uuid: '17b8a3a8-4ae1-4b2c-8a61-9f5f3fce3d77',
+    items: [
+      {
+        id: '0328f6ae-f146-4862-886a-1e5f4c5c908d',
+        scannedAt: '2026.02.21',
+        status: 'safe',
+        url: 'https://openai.com',
+      },
+      {
+        id: '947d0d5f-d87c-4816-a835-12eb3245c135',
+        scannedAt: '2026.02.17',
+        status: 'warning',
+        url: 'https://example-warning-site.com',
+      },
+      {
+        id: '82c0cb52-c9a6-47a5-8bd6-bf5c66843115',
+        scannedAt: '2026.02.02',
+        status: 'critical',
+        url: 'https://example-critical-site.com',
+      },
+    ],
+  },
+};
+
+export async function fetchScanListPageData(uuid: string): Promise<ScanListPageData> {
+  const pageData = mockScanListPageDataByUuid[uuid];
+
+  if (pageData) {
+    return Promise.resolve(pageData);
+  }
+
+  return Promise.resolve({
+    items: [],
+    uuid,
+  });
+}
+
+export function getInitialScanListPageData(uuid: string): ScanListPageData {
+  return (
+    mockScanListPageDataByUuid[uuid] ?? {
+      items: [],
+      uuid,
+    }
+  );
+}

--- a/src/pages/ScanList/hooks/useScanListPage.ts
+++ b/src/pages/ScanList/hooks/useScanListPage.ts
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react';
+
+import {
+  defaultScanListUuid,
+  fetchScanListPageData,
+  getInitialScanListPageData,
+} from '../api/fetchScanListPageData';
+
+import type { ScanListPageData } from '../types/scanListPage.types';
+
+type UseScanListPageReturn = {
+  scanListPageData: ScanListPageData;
+  scanListUuid: string;
+};
+
+function isUuid(value: string) {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+function resolveInitialScanListUuid() {
+  if (typeof window === 'undefined') {
+    return defaultScanListUuid;
+  }
+
+  const uuidParam = new URLSearchParams(window.location.search).get('uuid')?.trim();
+
+  if (uuidParam && isUuid(uuidParam)) {
+    return uuidParam;
+  }
+
+  return defaultScanListUuid;
+}
+
+function updateUuidSearchParam(uuid: string) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const searchParams = new URLSearchParams(window.location.search);
+  searchParams.set('uuid', uuid);
+
+  const nextSearch = searchParams.toString();
+  const nextUrl = nextSearch
+    ? `${window.location.pathname}?${nextSearch}`
+    : window.location.pathname;
+
+  window.history.replaceState(null, '', nextUrl);
+}
+
+export function useScanListPage(): UseScanListPageReturn {
+  const [scanListUuid] = useState(resolveInitialScanListUuid);
+  const [scanListPageData, setScanListPageData] = useState<ScanListPageData>(() =>
+    getInitialScanListPageData(resolveInitialScanListUuid()),
+  );
+
+  useEffect(() => {
+    updateUuidSearchParam(scanListUuid);
+
+    let isMounted = true;
+
+    const loadScanListPageData = async () => {
+      const response = await fetchScanListPageData(scanListUuid);
+
+      if (isMounted) {
+        setScanListPageData(response);
+      }
+    };
+
+    void loadScanListPageData();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [scanListUuid]);
+
+  return {
+    scanListPageData,
+    scanListUuid,
+  };
+}

--- a/src/pages/ScanList/hooks/useScanListPage.ts
+++ b/src/pages/ScanList/hooks/useScanListPage.ts
@@ -50,7 +50,7 @@ function updateUuidSearchParam(uuid: string) {
 export function useScanListPage(): UseScanListPageReturn {
   const [scanListUuid] = useState(resolveInitialScanListUuid);
   const [scanListPageData, setScanListPageData] = useState<ScanListPageData>(() =>
-    getInitialScanListPageData(resolveInitialScanListUuid()),
+    getInitialScanListPageData(scanListUuid),
   );
 
   useEffect(() => {
@@ -59,10 +59,18 @@ export function useScanListPage(): UseScanListPageReturn {
     let isMounted = true;
 
     const loadScanListPageData = async () => {
-      const response = await fetchScanListPageData(scanListUuid);
+      try {
+        const response = await fetchScanListPageData(scanListUuid);
 
-      if (isMounted) {
-        setScanListPageData(response);
+        if (isMounted) {
+          setScanListPageData(response);
+        }
+      } catch (error) {
+        console.error('Failed to load scan list page data.', error);
+
+        if (isMounted) {
+          setScanListPageData(getInitialScanListPageData(scanListUuid));
+        }
       }
     };
 

--- a/src/pages/ScanList/index.ts
+++ b/src/pages/ScanList/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ScanListPage';

--- a/src/pages/ScanList/styles/scanListPage.css.ts
+++ b/src/pages/ScanList/styles/scanListPage.css.ts
@@ -1,0 +1,201 @@
+import { style, styleVariants } from '@vanilla-extract/css';
+
+import { vars } from '@/vars.css';
+
+const bpTablet = 'screen and (min-width: 768px)';
+
+export const page = style({
+  minHeight: '100vh',
+  backgroundColor: vars.colors.white,
+});
+
+export const shell = style({
+  boxSizing: 'border-box',
+  width: '100%',
+  maxWidth: '440px',
+  margin: '0 auto',
+  padding: `28px ${vars.spacing.md} 48px`,
+  display: 'grid',
+  gap: '28px',
+  '@media': {
+    [bpTablet]: {
+      maxWidth: '520px',
+      padding: `40px ${vars.spacing.xl} 64px`,
+    },
+  },
+});
+
+export const intro = style({
+  display: 'grid',
+  gap: vars.spacing.sm,
+});
+
+export const title = style({
+  margin: 0,
+  color: '#1f2937',
+  fontSize: 'clamp(34px, 8vw, 48px)',
+  fontWeight: vars.font.weight.bold,
+  lineHeight: 1.12,
+  letterSpacing: '-0.03em',
+});
+
+export const description = style({
+  margin: 0,
+  color: '#60656f',
+  fontSize: vars.font.size.lg,
+  lineHeight: 1.5,
+});
+
+export const helper = style({
+  margin: 0,
+  color: '#9aa3b2',
+  fontSize: vars.font.size.xs,
+  lineHeight: 1.5,
+});
+
+export const listSection = style({
+  display: 'grid',
+  gap: vars.spacing.md,
+});
+
+export const list = style({
+  margin: 0,
+  padding: 0,
+  listStyle: 'none',
+  display: 'grid',
+  gap: '22px',
+});
+
+export const card = style({
+  position: 'relative',
+  display: 'grid',
+  gridTemplateColumns: '52px minmax(0, 1fr)',
+  alignItems: 'center',
+  gap: vars.spacing.md,
+  minHeight: '96px',
+  padding: '26px 22px 24px',
+  borderRadius: '30px',
+  boxShadow: '0 12px 30px rgba(15, 23, 42, 0.07)',
+  border: '1px solid rgba(15, 23, 42, 0.04)',
+});
+
+export const cardTone = styleVariants({
+  critical: {
+    background: 'linear-gradient(180deg, #fff4f3 0%, #fff0f0 100%)',
+  },
+  safe: {
+    background: 'linear-gradient(180deg, #f1fff7 0%, #eefcf4 100%)',
+  },
+  warning: {
+    background: 'linear-gradient(180deg, #fffdf2 0%, #fffbee 100%)',
+  },
+});
+
+export const cardIconWrap = style({
+  width: '48px',
+  height: '48px',
+  borderRadius: '50%',
+  display: 'grid',
+  placeItems: 'center',
+});
+
+export const cardIconWrapTone = styleVariants({
+  critical: {
+    backgroundColor: 'rgba(255, 103, 103, 0.12)',
+  },
+  safe: {
+    backgroundColor: 'rgba(17, 212, 131, 0.12)',
+  },
+  warning: {
+    backgroundColor: 'rgba(242, 223, 13, 0.18)',
+  },
+});
+
+export const cardIcon = style({
+  width: '26px',
+  height: '26px',
+  objectFit: 'contain',
+});
+
+export const cardContent = style({
+  minWidth: 0,
+  display: 'grid',
+  gap: '8px',
+});
+
+export const cardUrl = style({
+  margin: 0,
+  color: '#24292f',
+  fontSize: 'clamp(16px, 4vw, 20px)',
+  fontWeight: vars.font.weight.bold,
+  lineHeight: 1.35,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+});
+
+export const cardMeta = style({
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: '6px',
+  color: '#616975',
+  fontSize: vars.font.size.sm,
+  fontWeight: vars.font.weight.medium,
+});
+
+export const metaIcon = style({
+  width: '14px',
+  height: '14px',
+  display: 'inline-flex',
+  flexShrink: 0,
+});
+
+export const badge = style({
+  position: 'absolute',
+  top: '-12px',
+  right: '24px',
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '6px',
+  minWidth: '72px',
+  height: '28px',
+  padding: '0 12px',
+  borderRadius: '999px',
+  boxShadow: '0 8px 16px rgba(15, 23, 42, 0.12)',
+  fontSize: vars.font.size.sm,
+  fontWeight: vars.font.weight.bold,
+});
+
+export const badgeTone = styleVariants({
+  critical: {
+    backgroundColor: '#ff6b65',
+    color: vars.colors.white,
+  },
+  safe: {
+    backgroundColor: '#28e56d',
+    color: '#0e3b1f',
+  },
+  warning: {
+    backgroundColor: '#ffd84b',
+    color: '#3f3500',
+  },
+});
+
+export const badgeIcon = style({
+  width: '12px',
+  height: '12px',
+  display: 'inline-flex',
+  flexShrink: 0,
+});
+
+export const emptyState = style({
+  padding: '32px 24px',
+  borderRadius: '28px',
+  border: `1px dashed ${vars.colors.border}`,
+  backgroundColor: '#fafafa',
+  textAlign: 'center',
+  color: vars.colors.subText,
+  fontSize: vars.font.size.md,
+  lineHeight: 1.6,
+});

--- a/src/pages/ScanList/styles/scanListPage.css.ts
+++ b/src/pages/ScanList/styles/scanListPage.css.ts
@@ -129,9 +129,12 @@ export const cardUrl = style({
   fontSize: 'clamp(16px, 4vw, 20px)',
   fontWeight: vars.font.weight.bold,
   lineHeight: 1.35,
+  display: '-webkit-box',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
+  overflowWrap: 'anywhere',
+  WebkitBoxOrient: 'vertical',
+  WebkitLineClamp: 2,
 });
 
 export const cardMeta = style({

--- a/src/pages/ScanList/types/scanListPage.types.ts
+++ b/src/pages/ScanList/types/scanListPage.types.ts
@@ -1,0 +1,13 @@
+export type ScanListStatus = 'safe' | 'warning' | 'critical';
+
+export type ScanListItem = {
+  id: string;
+  scannedAt: string;
+  status: ScanListStatus;
+  url: string;
+};
+
+export type ScanListPageData = {
+  items: ScanListItem[];
+  uuid: string;
+};

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -3,6 +3,7 @@ import { Outlet, createRootRoute, createRoute, createRouter } from '@tanstack/re
 import CaptchaPage from '@/pages/Captcha';
 import HomePage from '@/pages/Home';
 import LoadingPage from '@/pages/Loading';
+import QRScanPage from '@/pages/QRScan';
 import ReportPage from '@/pages/Report';
 import ResultCriticalPage from '@/pages/ResultCritical';
 import ResultNonUrlPage from '@/pages/ResultNonUrl';
@@ -34,6 +35,12 @@ const loadingRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/loading',
   component: LoadingPage,
+});
+
+const qrScanRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/qr-scan',
+  component: QRScanPage,
 });
 
 const reportRoute = createRoute({
@@ -76,6 +83,7 @@ const routeTree = rootRoute.addChildren([
   indexRoute,
   captchaRoute,
   loadingRoute,
+  qrScanRoute,
   reportRoute,
   scanHistoryRoute,
   resultCriticalRoute,

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -10,6 +10,7 @@ import ResultNonUrlPage from '@/pages/ResultNonUrl';
 import ResultSafePage from '@/pages/ResultSafe';
 import ResultWarningPage from '@/pages/ResultWarning';
 import ScanHistoryPage from '@/pages/ScanHistory';
+import ScanListPage from '@/pages/ScanList';
 
 function RootLayout() {
   return <Outlet />;
@@ -55,6 +56,12 @@ const scanHistoryRoute = createRoute({
   component: ScanHistoryPage,
 });
 
+const scanListRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/scan-list',
+  component: ScanListPage,
+});
+
 const resultCriticalRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/result/critical',
@@ -86,6 +93,7 @@ const routeTree = rootRoute.addChildren([
   qrScanRoute,
   reportRoute,
   scanHistoryRoute,
+  scanListRoute,
   resultCriticalRoute,
   resultNonUrlRoute,
   resultSafeRoute,


### PR DESCRIPTION
## Summary

#23 

## Tasks
- 스캔 이력 목록창 UI 구현. 
- QR 스캔 페이지 레이아웃 구현
- 피그마 디자인 기반 UUID 스캔 이력 조회 화면 구현

## Screenshot
<img width="737" height="790" alt="image" src="https://github.com/user-attachments/assets/df28704e-1785-472a-ad77-9aaf7e5b8e91" />
<img width="1423" height="855" alt="image" src="https://github.com/user-attachments/assets/0b3673bd-ade5-4aa5-85e6-968fb98ff658" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * QR 스캔 페이지 추가: 실시간 카메라 미리보기, 사진 촬영 및 갤러리 업로드 지원
  * 촬영 플래시 오버레이 및 스캔 애니메이션 도입으로 시각적 피드백 강화
  * 최근 스캔 활동(미리보기 포함) 표시 기능 추가
  * 스캔 이력 페이지 추가: 항목별 상태 표시(안전/주의/위험) 및 스캔 일시 노출
  * 홈 네비게이션에 QR 스캔 및 스캔 목록 링크 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->